### PR TITLE
更新 Serilog 和 MongoDB 包版本

### DIFF
--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -38,7 +38,7 @@
 		<PackageReference Include="Serilog.Sinks.EventLog" Version="4.0.1-dev-00087" />
 		<PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
 		<PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
-		<PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.0" />
+		<PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1-dev-00351" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
 	</ItemGroup>
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,10 +18,10 @@
     <PackageVersion Include="Backport.System.Threading.Lock" Version="2.0.0" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.5.0-beta.79" />
     <PackageVersion Include="MessagePack" Version="3.0.134-beta" />
-    <PackageVersion Include="MongoDB.Bson" Version="2.28.0" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
-    <PackageVersion Include="MongoDB.Driver.Core" Version="2.28.0" />
-    <PackageVersion Include="MongoDB.Driver.GridFS" Version="2.28.0" />
+    <PackageVersion Include="MongoDB.Bson" Version="2.29.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.29.0" />
+    <PackageVersion Include="MongoDB.Driver.Core" Version="2.29.0" />
+    <PackageVersion Include="MongoDB.Driver.GridFS" Version="2.29.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.0.0-rc.11" />
     <PackageVersion Include="Serilog" Version="4.0.2-dev-02226" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.49.2-preview.0.44" />


### PR DESCRIPTION
在 `WebApi.Test.Unit.csproj` 文件中，将 `Serilog.Sinks.OpenTelemetry` 包的版本从 `4.1.0` 更新到了 `4.1.1-dev-00351`。 在 `Directory.Packages.props` 文件中，将 `MongoDB.Bson`、`MongoDB.Driver`、`MongoDB.Driver.Core` 和 `MongoDB.Driver.GridFS` 包的版本从 `2.28.0` 更新到了 `2.29.0`。