### PR TITLE
dump: 更新 Backport.System.Threading.Lock 包版本

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <Project>
   <PropertyGroup>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
@@ -16,7 +15,7 @@
     <NoWarn>$(NoWarn);IDE0130;</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Backport.System.Threading.Lock" Version="3.1.1" />
+    <PackageVersion Include="Backport.System.Threading.Lock" Version="3.1.4" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.5.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.1.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.0.0" />


### PR DESCRIPTION
将 `Backport.System.Threading.Lock` 包的版本从 `3.1.1` 升级到 `3.1.4`。其他 XML 结构保持不变，进行了格式微调。