### PR TITLE
feat: 添加OepnObserve和otel-conllector的使用案例.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,5 @@ FodyWeavers.xsd
 
 # JetBrains
 .idea/
+
+/obdata

--- a/EasilyNET.sln
+++ b/EasilyNET.sln
@@ -31,6 +31,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		EasilyNET.snk = EasilyNET.snk
 		gitemoji.md = gitemoji.md
 		LICENSE = LICENSE
+		otel-collector-config.yaml = otel-collector-config.yaml
 		Push.ps1 = Push.ps1
 		README.md = README.md
 		Test.ps1 = Test.ps1

--- a/docker-compose.basic.service.yml
+++ b/docker-compose.basic.service.yml
@@ -3,6 +3,7 @@
 services:
   garnet:
     image: ghcr.io/microsoft/garnet
+    container_name: garnet
     environment:
       - TZ=Asia/Chongqing
     ports:
@@ -14,6 +15,7 @@ services:
 
   rabbit:
     image: ghcr.io/joesdu/rabbitmq-dlx:latest
+    container_name: rabbit
     environment:
       - TZ=Asia/Chongqing
       - RABBITMQ_DEFAULT_USER=admin
@@ -24,6 +26,7 @@ services:
 
   aspire_dashboard:
     image: mcr.microsoft.com/dotnet/nightly/aspire-dashboard:latest
+    container_name: aspire_dashboard
     environment:
       - TZ=Asia/Chongqing
       - DASHBOARD__OTLP__AUTHMODE=ApiKey
@@ -33,4 +36,42 @@ services:
       - DASHBOARD__TELEMETRYLIMITS__MAXMETRICSCOUNT=1000
     ports:
       - "18888:18888"
-      - "4317:18889"
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib
+    container_name: otel-collector
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+    environment:
+      - TZ=Asia/Chongqing
+      # 由于 OpenObserve 服务端的这个Token老是不固定,所以每次都需要更改一下才行
+      - OBAUTHORIZATION=Basic ZHlnb29kQG91dGxvb2suY29tOnY5UWtJYmp1R2N6U1hUYzA=
+    ports:
+      # - "1888:1888"   # pprof扩展
+      # - "13133:13133" # health_check扩展
+      # - "55679:55679" # zpages扩展
+      # - "8888:8888"   # Collector公开的Prometheus指标
+      # - "8889:8889"   # Prometheus导出器指标
+      - "4317:4317"   # OTLP gRPC接收器
+      - "4318:4318"   # OTLP http接收器
+
+  openobserve:
+    image: public.ecr.aws/zinclabs/openobserve:latest
+    container_name: openobserve
+    volumes:
+      - obdata:/data
+    environment:
+      - TZ=Asia/Chongqing
+      - ZO_DATA_DIR=/data
+      - ZO_ROOT_USER_EMAIL=dygood@outlook.com
+      - ZO_ROOT_USER_PASSWORD=Complexpass#123
+    ports:
+      - "5080:5080"
+
+volumes:
+  obdata:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ./obdata

--- a/docker-compose.mongo.rs.yml
+++ b/docker-compose.mongo.rs.yml
@@ -3,6 +3,7 @@
 services:
   mongo_primary:
     image: bitnami/mongodb:latest
+    container_name: mongo_primary
     environment:
       - TZ=Asia/Chongqing
       - MONGODB_ADVERTISED_HOSTNAME=host.docker.internal
@@ -18,6 +19,7 @@ services:
 
   mongo_secondary:
     image: bitnami/mongodb:latest
+    container_name: mongo_secondary
     depends_on:
       - mongo_primary
     environment:
@@ -35,6 +37,7 @@ services:
 
   mongo_arbiter:
     image: bitnami/mongodb:latest
+    container_name: mongo_arbiter
     depends_on:
       - mongo_primary
     environment:

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -1,0 +1,42 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  otlp/aspire:
+    endpoint: aspire_dashboard:18889
+    headers:
+      x-otlp-api-key: "rVmuMdaqCEruWEbKANjmcIQMnKIhDiLUYSFHaZAVlMktmwDhMUAPIZyfizmoLuSwAePPVhhPigpJUIsAsPZcwfmaMnBxxRuxatrrHNSOKUxUVGFlYQtGtbqtOPasMvPd"
+    tls:
+      insecure: true
+
+  otlp/openobserve:
+    endpoint: openobserve:5081
+    headers:
+      Authorization: "${OBAUTHORIZATION}"
+      organization: default
+      stream-name: default
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/aspire, otlp/openobserve]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/aspire, otlp/openobserve]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/aspire, otlp/openobserve]

--- a/sample/WebApi.Test.Unit/Program.cs
+++ b/sample/WebApi.Test.Unit/Program.cs
@@ -40,12 +40,8 @@ builder.Host.UseSerilog((hbc, lc) =>
           var otel = hbc.Configuration.GetSection("OpenTelemetry");
           wt.OpenTelemetry(c =>
           {
+              c.Endpoint = new(otel["OTEL_EXPORTER_OTLP_ENDPOINT"] ?? "http://localhost:4317");
               c.Protocol = OtlpProtocol.Grpc;
-              c.Endpoint = otel["OTEL_EXPORTER_OTLP_ENDPOINT"] ?? "http://localhost:4317";
-              c.Headers = new Dictionary<string, string>
-              {
-                  ["x-otlp-api-key"] = otel["DASHBOARD_OTLP_PRIMARYAPIKEY"] ?? string.Empty
-              };
               c.ResourceAttributes = new Dictionary<string, object>
               {
                   ["service.name"] = Constant.InstanceName

--- a/sample/WebApi.Test.Unit/appsettings.json
+++ b/sample/WebApi.Test.Unit/appsettings.json
@@ -25,8 +25,6 @@
     "Garnet": "host.docker.internal:6379,password=a123456"
   },
   "OpenTelemetry": {
-    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
-    "DASHBOARD_OTLP_PRIMARYAPIKEY":
-      "rVmuMdaqCEruWEbKANjmcIQMnKIhDiLUYSFHaZAVlMktmwDhMUAPIZyfizmoLuSwAePPVhhPigpJUIsAsPZcwfmaMnBxxRuxatrrHNSOKUxUVGFlYQtGtbqtOPasMvPd"
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"
   }
 }


### PR DESCRIPTION
更新配置文件以支持 OpenTelemetry 和服务管理

- 更新 `.gitignore`，忽略 `MigrationBackup/` 目录。
- 添加 `otel-collector-config.yaml` 和 `openobserve` 服务配置。
- 在 `docker-compose.basic.service.yml` 中添加 `rabbit`、`aspire_dashboard` 和 `otel-collector` 服务。
- 在 `docker-compose.mongo.rs.yml` 中添加 MongoDB 服务配置。
- 在 `otel-collector-config.yaml` 中配置 OpenTelemetry 的接收器、处理器和导出器。
- 更新 `Program.cs` 中的 OpenTelemetry 配置。
- 在 `OpenTelemetryModule.cs` 中添加日志导出器配置。
- 移除 `appsettings.json` 中无效内容，保留 OpenTelemetry 端点配置。