### PR TITLE
feat: 重构 KeyedServiceTestController 和相关类

### DIFF
--- a/sample/WebApi.Test.Unit/Controllers/KeyedServiceTestController.cs
+++ b/sample/WebApi.Test.Unit/Controllers/KeyedServiceTestController.cs
@@ -1,20 +1,16 @@
 using EasilyNET.AutoDependencyInjection.Core.Attributes;
 using EasilyNET.Core.Attributes;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 // ReSharper disable ClassNeverInstantiated.Global
 
 namespace WebApi.Test.Unit.Controllers;
 
-/// <summary>
-/// KeyedServiceTest
-/// </summary>
+/// <inheritdoc />
 [Route("api/[controller]")]
 [ApiController]
 [ApiGroup("KeyedServiceTest", "KeyedServiceTestController")]
-[Authorize]
-public class KeyedServiceTestController(IServiceProvider sp, IKeyedServiceTest kst2) : ControllerBase
+public class KeyedServiceTestController(IServiceProvider sp, [FromKeyedServices("helloKey")] IKeyedServiceTest2 kst2) : ControllerBase
 {
     /// <summary>
     /// ShowHello
@@ -32,8 +28,7 @@ public class KeyedServiceTestController(IServiceProvider sp, IKeyedServiceTest k
     /// </summary>
     /// <returns></returns>
     [HttpGet("HelloKeyedService2")]
-    [AllowAnonymous]
-    public string ShowHello2() => kst2.ShowHello();
+    public string ShowHello2() => kst2.ShowHello2();
 
     /// <summary>
     /// ShowHello3
@@ -50,15 +45,26 @@ public class KeyedServiceTestController(IServiceProvider sp, IKeyedServiceTest k
 /// <summary>
 /// KeyedServiceTest
 /// </summary>
-[DependencyInjection(ServiceLifetime.Transient, ServiceKey = "helloKey")]
-public sealed class KeyedServiceTest : IKeyedServiceTest
+[DependencyInjection(ServiceLifetime.Transient, AsType = typeof(IKeyedServiceTest2), ServiceKey = "helloKey")]
+public sealed class KeyedServiceTest : IKeyedServiceTest, IKeyedServiceTest2
+{
+    /// <inheritdoc />
+    public string ShowHello() => "Hello, KeyedServiceTest!";
+
+    /// <inheritdoc />
+    public string ShowHello2() => "Hello2, KeyedServiceTest!";
+}
+
+/// <summary>
+/// IKeyedServiceTest2
+/// </summary>
+public interface IKeyedServiceTest2
 {
     /// <summary>
-    /// ShowHello
+    /// ShowHello2
     /// </summary>
     /// <returns></returns>
-    // ReSharper disable once MemberCanBeMadeStatic.Global
-    public string ShowHello() => "Hello, KeyedServiceTest!";
+    string ShowHello2();
 }
 
 /// <summary>


### PR DESCRIPTION
- 移除对 Microsoft.AspNetCore.Authorization 的引用，删除 [Authorize] 特性。
- 修改 KeyedServiceTestController 构造函数，使用 FromKeyedServices 注入 IKeyedServiceTest2。
- 更新 ShowHello2 方法实现，调用 kst2.ShowHello2()。
- 修改 KeyedServiceTest 类的 DependencyInjection 特性，新增 ShowHello2 方法实现。
- 新增 IKeyedServiceTest2 接口，定义 ShowHello2 方法，移除 ShowHello 的默认实现。