### PR TITLE
feat: 更新依赖项并简化构造函数逻辑

### DIFF
--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -16,8 +16,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0-rc.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.10.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.10.0" />

--- a/src/EasilyNET.Mongo.AspNetCore/TimeSeriesCollectionExtensions.cs
+++ b/src/EasilyNET.Mongo.AspNetCore/TimeSeriesCollectionExtensions.cs
@@ -9,6 +9,8 @@ using MongoDB.Driver;
 // ReSharper disable UnusedType.Global
 // ReSharper disable UnusedMember.Global
 
+#pragma warning disable IDE0130 // 命名空间与文件夹结构不匹配
+
 namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>


### PR DESCRIPTION
在 `WebApi.Test.Unit.csproj` 中，将 `OpenTelemetry.Exporter.OpenTelemetryProtocol` 和 `OpenTelemetry.Extensions.Hosting` 的版本从 `1.11.0-rc.1` 更新为 `1.11.0`。

在 `ServiceProviderExtension.cs` 中，简化了 `CreateInstance` 方法的构造函数获取逻辑，使用空合并运算符处理构造函数为 `null` 的情况，并抛出相应的异常信息。

在 `TimeSeriesCollectionExtensions.cs` 中，添加了 `#pragma warning disable IDE0130` 指令以禁用命名空间与文件夹结构不匹配的警告，并定义了命名空间 `Microsoft.Extensions.DependencyInjection`。