### PR TITLE
更新 Spectre.Console.Json 包版本

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.1.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.0-alpha.0" />
     <PackageVersion Include="Serilog" Version="4.1.0-dev-02238" />
-    <PackageVersion Include="Spectre.Console.Json" Version="0.49.2-preview.0.73" />
+    <PackageVersion Include="Spectre.Console.Json" Version="0.49.2-preview.0.74" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
     <!--microsoft asp.net core -->


### PR DESCRIPTION
将 `Spectre.Console.Json` 包的版本从 `0.49.2-preview.0.73` 升级到 `0.49.2-preview.0.74`。