### PR TITLE
更新多个 NuGet 包版本

### DIFF
--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
@@ -30,7 +30,7 @@
     <PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-    <PackageReference Include="System.Management" Version="9.0.1" />
+    <PackageReference Include="System.Management" Version="9.0.2" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,16 +20,16 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.1.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.0-alpha.0" />
     <PackageVersion Include="Serilog" Version="4.1.0-dev-02238" />
-    <PackageVersion Include="Spectre.Console.Json" Version="0.49.2-preview.0.74" />
+    <PackageVersion Include="Spectre.Console.Json" Version="0.49.2-preview.0.75" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
     <!--microsoft asp.net core -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.1.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.2.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.2" />
   </ItemGroup>
   <!-- 自定义任务来检查 TargetFramework -->
   <PropertyGroup>


### PR DESCRIPTION
更新了 `Microsoft.AspNetCore.Authentication.JwtBearer`、`Microsoft.AspNetCore.OpenApi`、`Microsoft.Extensions.Caching.StackExchangeRedis` 和 `Microsoft.Extensions.Http.Resilience` 的版本，从 9.0.1 和 9.1.0 更新到 9.0.2 和 9.2.0。 同时，`System.Management` 包版本从 9.0.1 更新到 9.0.2，`Spectre.Console.Json` 包版本从 0.49.2-preview.0.74 更新到 0.49.2-preview.0.75。 此外，多个 `Microsoft.Extensions` 相关的包版本也进行了更新，从 9.0.1 和 9.1.0 更新到 9.0.2 和 9.2.0。