### PR TITLE
更新依赖包版本

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,8 +17,8 @@
   <ItemGroup>
     <PackageVersion Include="Backport.System.Threading.Lock" Version="3.1.4" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.5.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.1.0" />
-    <PackageVersion Include="RabbitMQ.Client" Version="7.1.0-alpha.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.2.0" />
+    <PackageVersion Include="RabbitMQ.Client" Version="7.1.0-alpha.1" />
     <PackageVersion Include="Serilog" Version="4.1.0-dev-02238" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.49.2-preview.0.75" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />

--- a/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
+++ b/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
@@ -9,8 +9,8 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0-preview-25107-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
在 `Directory.Packages.props` 文件中，`MongoDB.Driver` 的版本从 `3.1.0` 更新到 `3.2.0`，`RabbitMQ.Client` 的版本从 `7.1.0-alpha.0` 更新到 `7.1.0-alpha.1`。

在 `EasilyNET.Test.Unit.csproj` 文件中，`MSTest.TestAdapter` 和 `MSTest.TestFramework` 的版本从 `3.7.3` 更新到 `3.8.0`。