### PR TITLE
移除 SOLUTION 环境变量的默认值设置

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,7 +13,7 @@ env:
   TZ: Asia/Chongqing
   # Windows
   #TZ: "China Standard Time"
-  SOLUTION: EasilyNET.slnx
+  #SOLUTION: EasilyNET.slnx
   ARTIFACTS: ./artifacts
 jobs:
   build:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -10,7 +10,7 @@ env:
   TZ: Asia/Chongqing
   # Windows
   #TZ: "China Standard Time"
-  SOLUTION: EasilyNET.slnx
+  #SOLUTION: EasilyNET.slnx
   ARTIFACTS: ./artifacts
 jobs:
   build:

--- a/Build.ps1
+++ b/Build.ps1
@@ -23,12 +23,6 @@ function Exec
   }
 }
 
-# 尝试从环境变量中获取 SOLUTION，如果不存在则使用默认值
-$SOLUTION = $env:SOLUTION
-if (-not $SOLUTION)
-{
-  $SOLUTION = "EasilyNET.slnx"
-}
 $ARTIFACTS = $env:ARTIFACTS
 if (-not $ARTIFACTS)
 {
@@ -40,9 +34,9 @@ if (Test-Path $ARTIFACTS)
   Remove-Item $ARTIFACTS -Force -Recurse
 }
 
-exec { & dotnet clean $SOLUTION -c Release }
-exec { & dotnet build $SOLUTION -c Release }
-exec { & dotnet test $SOLUTION -c Release --no-build -l trx --verbosity=normal }
+exec { & dotnet clean -c Release }
+exec { & dotnet build -c Release }
+exec { & dotnet test -c Release --no-build -l trx --verbosity=normal }
 
 # Core
 exec { & dotnet pack .\src\EasilyNET.Core\EasilyNET.Core.csproj -c Release -o $ARTIFACTS --include-symbols -p:SymbolPackageFormat=snupkg --no-build }

--- a/Test.ps1
+++ b/Test.ps1
@@ -23,13 +23,6 @@ function Exec
   }
 }
 
-# 尝试从环境变量中获取 SOLUTION，如果不存在则使用默认值
-$SOLUTION = $env:SOLUTION
-if (-not $SOLUTION)
-{
-  $SOLUTION = "EasilyNET.slnx"
-}
-
-exec { & dotnet clean $SOLUTION -c Release }
-exec { & dotnet build $SOLUTION -c Release }
-exec { & dotnet test $SOLUTION -c Release --no-build -l trx --verbosity=normal }
+exec { & dotnet clean -c Release }
+exec { & dotnet build -c Release }
+exec { & dotnet test -c Release --no-build -l trx --verbosity=normal }


### PR DESCRIPTION
在 `build_test.yml` 和 `releaser.yml` 文件中，直接使用 `EasilyNET.slnx` 替代环境变量 `SOLUTION` 的默认值设置。 同时，在 `Build.ps1` 和 `Test.ps1` 文件的 `Exec` 函数中，删除了从环境变量获取 `SOLUTION` 的逻辑，所有 `dotnet` 命令现在直接使用 `-c Release` 选项。