### PR TITLE
更新依赖包版本

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Backport.System.Threading.Lock" Version="3.1.4" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.5.1" />
     <PackageVersion Include="MongoDB.Driver" Version="3.2.0" />
-    <PackageVersion Include="RabbitMQ.Client" Version="7.1.0-alpha.1" />
+    <PackageVersion Include="RabbitMQ.Client" Version="7.1.0" />
     <PackageVersion Include="Serilog" Version="4.1.0-dev-02238" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.49.2-preview.0.75" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />

--- a/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
+++ b/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
@@ -9,8 +9,8 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0-preview-25107-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
在 `Directory.Packages.props` 文件中，`RabbitMQ.Client` 的版本从 `7.1.0-alpha.1` 更新为 `7.1.0`。

在 `EasilyNET.Test.Unit.csproj` 文件中，`MSTest.TestAdapter` 和 `MSTest.TestFramework` 的版本从 `3.8.1` 更新为 `3.8.2`。