### PR TITLE
feat: 更新依赖包版本

### DIFF
--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageVersion Include="Backport.System.Threading.Lock" Version="3.1.4" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.5.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.2.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.2.1" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.0" />
     <PackageVersion Include="Serilog" Version="4.1.0-dev-02238" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.49.2-preview.0.75" />


### PR DESCRIPTION
在 `WebApi.Test.Unit.csproj` 文件中，`Microsoft.VisualStudio.Azure.Containers.Tools.Targets` 的版本从 `1.21.1` 更新为 `1.21.2`。

在 `Directory.Packages.props` 文件中，`MongoDB.Driver` 的版本从 `3.2.0` 更新为 `3.2.1`。