### PR TITLE
feat: 更新项目以支持 .NET 10 版本

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -39,8 +39,8 @@ body:
       multiple: true
       description: What version of our software are you running?
       options:
-        - .NET10(LTS)
-        - .NET9(STS) (Default)
+        - .NET10(LTS) (Default)
+        - .NET9(STS)
         - .NET8(LTS)
     validations:
       required: true

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - main
 env:
-  DOTNET_VERSION: "9.0.x"
   # Linux
   TZ: Asia/Chongqing
   # Windows
@@ -69,7 +68,10 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Build and Test
         run: ./Test.ps1

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -5,7 +5,6 @@ on:
     tags:
       - "*.*.*"
 env:
-  DOTNET_VERSION: "9.0.x"
   # Linux
   TZ: Asia/Chongqing
   # Windows
@@ -65,10 +64,13 @@ jobs:
       #- name: Display the latest tag
       #  run: Write-Host $EASILYNET_VERSION
 
-      - name: Setup .Net SDK
+      - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Build and Test
         run: ./Build.ps1

--- a/sample/WebApi.Test.Unit/Dockerfile
+++ b/sample/WebApi.Test.Unit/Dockerfile
@@ -1,14 +1,14 @@
 # 请参阅 https://aka.ms/customizecontainer 以了解如何自定义调试容器，以及 Visual Studio 如何使用此 Dockerfile 生成映像以更快地进行调试。
 
 # 此阶段用于在快速模式(默认为调试配置)下从 VS 运行时
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-preview AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 
 
 # 此阶段用于生成服务项目
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-preview AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["src/Directory.Packages.props", "src/"]

--- a/sample/WebApi.Test.Unit/Program.cs
+++ b/sample/WebApi.Test.Unit/Program.cs
@@ -8,6 +8,8 @@ using Serilog.Sinks.SystemConsole.Themes;
 using WebApi.Test.Unit;
 using WebApi.Test.Unit.Common;
 
+#pragma warning disable CS1591 // 缺少对公共可见类型或成员的 XML 注释
+
 AssemblyHelper.LoadFromAllDll = false;
 // App init start time
 var appInitial = Stopwatch.GetTimestamp();

--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
@@ -10,9 +10,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0-preview.1.25120.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-preview.1.25120.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0-preview.1.25120.3" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
@@ -30,7 +30,7 @@
     <PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-    <PackageReference Include="System.Management" Version="9.0.2" />
+    <PackageReference Include="System.Management" Version="10.0.0-preview.1.25080.5" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,7 +8,7 @@
     <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <PropertyGroup>
@@ -20,16 +20,15 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.2.1" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.0" />
     <PackageVersion Include="Serilog" Version="4.1.0-dev-02238" />
-    <PackageVersion Include="Spectre.Console.Json" Version="0.49.2-preview.0.75" />
+    <PackageVersion Include="Spectre.Console.Json" Version="0.49.2-preview.0.76" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.2.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
     <!--microsoft asp.net core -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.1.25080.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0-preview.1.25080.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.1.25080.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.1.25080.5" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.2.0" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.2" />
   </ItemGroup>
   <!-- 自定义任务来检查 TargetFramework -->
   <PropertyGroup>

--- a/src/EasilyNET.Mongo.ConsoleDebug/EasilyNET.Mongo.ConsoleDebug.csproj
+++ b/src/EasilyNET.Mongo.ConsoleDebug/EasilyNET.Mongo.ConsoleDebug.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" />
     <PackageReference Include="Spectre.Console.Json" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EasilyNET.Core.Benchmark/EasilyNET.Core.Benchmark.csproj
+++ b/test/EasilyNET.Core.Benchmark/EasilyNET.Core.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
+++ b/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <NoWarn>$(NoWarn);NU5104;CS1591</NoWarn>


### PR DESCRIPTION
- 在 `bug.yml` 中添加 .NET 10 作为默认选项。
- 修改 `build_test.yml` 和 `releaser.yml` 中的 `DOTNET_VERSION` 环境变量，支持多个 .NET 版本。
- 更新 `Dockerfile` 基础镜像为 .NET 10 预览版。
- 在 `Program.cs` 中禁用 XML 注释缺失警告。
- 将 `WebApi.Test.Unit.csproj`、`EasilyNET.Mongo.ConsoleDebug.csproj`、`EasilyNET.Core.Benchmark.csproj` 和 `EasilyNET.Test.Unit.csproj` 的目标框架更新为 .NET 10。
- 更新 `Directory.Packages.props` 中的 NuGet 包版本以兼容 .NET 10。