### PR TITLE
feat: 更新多个NuGet包版本

### DIFF
--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0-preview.1.25120.3" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.3.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
@@ -26,7 +26,7 @@
     <PackageReference Include="RabbitMQ.Client.OpenTelemetry" Version="1.0.0-rc.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0-dev-02301" />
     <PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0-preview.1.25080.5" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.1.25080.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.1.25080.5" />
-    <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.3.0" />
   </ItemGroup>
   <!-- 自定义任务来检查 TargetFramework -->
   <PropertyGroup>


### PR DESCRIPTION
在 `WebApi.Test.Unit.csproj` 文件中，升级了 `Microsoft.AspNetCore.Authentication.JwtBearer` 和 `Microsoft.AspNetCore.OpenApi` 到版本 `9.0.3`，`Microsoft.Extensions.Http.Resilience` 到 `9.3.0`，以及 `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` 到 `1.22.0`。同时，将 `Serilog.Sinks.File` 的版本更新至 `7.0.0-dev-02301`。

在 `Directory.Packages.props` 文件中，`Microsoft.Extensions.Resilience` 的版本也进行了相应的升级。