### PR TITLE
feat: 调整依赖项版本

### DIFF
--- a/sample/WebApi.Test.Unit/Controllers/MongoTestController.cs
+++ b/sample/WebApi.Test.Unit/Controllers/MongoTestController.cs
@@ -111,7 +111,8 @@ public class MongoTestController(DbContext db) : ControllerBase
     /// <param name="id"></param>
     /// <returns></returns>
     [HttpGet("Test2")]
-    public async Task<MongoTest2> GetTest2(string id) => await db.Test2.Find(c => c.Id == id).SingleOrDefaultAsync();
+    public async Task<MongoTest2> GetTest2([DefaultValue(typeof(string), "1")] string id) =>
+        await db.Test2.Find(c => c.Id == id).SingleOrDefaultAsync();
 
     /// <summary>
     /// 查询测试Test2

--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0-preview.1.25120.3" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.3.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1-Preview.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />

--- a/src/EasilyNET.WebCore.Swagger/SwaggerGenOptionsExtensions.cs
+++ b/src/EasilyNET.WebCore.Swagger/SwaggerGenOptionsExtensions.cs
@@ -11,6 +11,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 // ReSharper disable UnusedType.Global
 // ReSharper disable UnusedMember.Global
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>


### PR DESCRIPTION
在 `MongoTestController.cs` 中，`GetTest2` 方法的 `id` 参数添加了默认值 "1"。 在 `WebApi.Test.Unit.csproj` 中，更新 `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` 的版本至 `1.22.1-Preview.1`。 在 `SwaggerGenOptionsExtensions.cs` 中，添加注释以禁用 ReSharper 对命名空间的检查。