### PR TITLE
更新 docker-compose 和包版本

### DIFF
--- a/docker-compose.basic.service.yml
+++ b/docker-compose.basic.service.yml
@@ -38,7 +38,7 @@ services:
       - "18888:18888"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
     container_name: otel-collector
     volumes:
       - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.0-beta.114" />
     <PackageVersion Include="MongoDB.Driver" Version="3.3.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
-    <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.2" />
+    <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.0" />
     <!--microsoft asp.net core -->


### PR DESCRIPTION
在 `docker-compose.basic.service.yml` 文件中，移除了环境变量 `DASHBOARD__TELEMETRYLIMITS__MAXMETRICSCOUNT=1000`，并更新了 `otel-collector` 的镜像地址。

在 `Directory.Packages.props` 文件中，更新了 `Spectre.Console.Json` 包的版本，从 `0.50.1-preview.0.2` 更改为 `0.50.1-preview.0.3`，同时移除了旧版本的声明。