### PR TITLE
fix: 增强日志记录和连接管理功能

### DIFF
--- a/sample/WebApi.Test.Unit/Program.cs
+++ b/sample/WebApi.Test.Unit/Program.cs
@@ -25,6 +25,10 @@ builder.Host.UseSerilog((hbc, lc) =>
       .MinimumLevel.Override("System", logLevel)
       // 添加下面这行来过滤掉 Microsoft.Extensions.Resilience 的日志
       .MinimumLevel.Override("Polly", LogEventLevel.Warning)
+      .MinimumLevel.Override("Microsoft.AspNetCore", logLevel)
+      .MinimumLevel.Override("Microsoft.AspNetCore.Cors.Infrastructure.CorsService", logLevel)
+      .MinimumLevel.Override("Microsoft.AspNetCore.Mvc", logLevel)
+      .MinimumLevel.Override("Microsoft.AspNetCore.Hosting", logLevel)
       .Enrich.FromLogContext()
       .WriteTo.Async(wt =>
       {

--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="RabbitMQ.Client.OpenTelemetry" Version="1.0.0-rc.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0-dev-02301" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0-dev-02302" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />


### PR DESCRIPTION
在 `Program.cs` 中添加了日志级别覆盖，以过滤特定日志信息。更新 `WebApi.Test.Unit.csproj` 中 `Serilog.Sinks.File` 的版本为稳定版 `7.0.0`。在 `EventBus.cs` 中优化了连接检查逻辑，确保在发布事件前检查连接状态并异步获取通道。最后，在 `PersistentConnection.cs` 中添加了连接状态检查和重连逻辑，改进了异常处理时的日志记录。