### PR TITLE
feat: 更新 BouncyCastle.Cryptography 版本为稳定版

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Backport.System.Threading.Lock" Version="3.1.4" />
-    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.0-beta.133" />
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.5" />


### PR DESCRIPTION
在 `Directory.Packages.props` 文件中，将 `BouncyCastle.Cryptography` 的版本号从 `2.6.0-beta.133` 更新为 `2.6.0`，以使用稳定版本的依赖项。