### PR TITLE
更新依赖包版本

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Backport.System.Threading.Lock" Version="3.1.4" />
-    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.0" />
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.1" />
     <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.5" />

--- a/test/EasilyNET.Core.Benchmark/EasilyNET.Core.Benchmark.csproj
+++ b/test/EasilyNET.Core.Benchmark/EasilyNET.Core.Benchmark.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
在 `Directory.Packages.props` 文件中，`BouncyCastle.Cryptography` 的版本从 `2.6.0` 更新为 `2.6.1`。

在 `EasilyNET.Core.Benchmark.csproj` 文件中，`BenchmarkDotNet` 的版本从 `0.14.0` 更新为 `0.15.0`。