### PR TITLE
feat: 更新 Serilog.Sinks.OpenTelemetry 版本

### DIFF
--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0-dev-02302" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.2" />
     <PackageReference Include="System.Management" Version="10.0.0-preview.4.25258.110" />
   </ItemGroup>


### PR DESCRIPTION
将 `Serilog.Sinks.OpenTelemetry` 的版本从 `4.2.0-dev-02302` 更新为 `4.2.0`，移除了开发版本，改为稳定版本。