### PR TITLE
chore: 更新 Spectre.Console.Json 包版本

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.1" />
     <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
-    <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.9" />
+    <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.10" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.2" />
     <!--microsoft asp.net core -->


### PR DESCRIPTION
将 `Spectre.Console.Json` 包的版本从 `0.50.1-preview.0.9` 更新至 `0.50.1-preview.0.10`。