### PR TITLE
feat: 添加时序集合索引管理功能,优化更多场景以及索引的处理逻辑.

### DIFF
--- a/EasilyNET.sln.DotSettings
+++ b/EasilyNET.sln.DotSettings
@@ -357,5 +357,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Huangdao/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=otel/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OTLP/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=timeseries/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ULID/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=yiji/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
在 `EasilyNET.sln.DotSettings` 中添加了 `timeseries` 词条。 在 `CollectionIndexExtensions.cs` 中实现了多个新方法以支持 MongoDB 索引管理，特别是时序集合的索引创建和管理，包括获取现有索引、生成所需索引、管理索引、检测时序集合及获取时序字段等功能。同时，增加了 `IndexDefinition` 类以封装索引信息，并增强了异常处理和日志记录。