### PR TITLE
feat: 更新依赖包版本

### DIFF
--- a/test/EasilyNET.Core.Benchmark/EasilyNET.Core.Benchmark.csproj
+++ b/test/EasilyNET.Core.Benchmark/EasilyNET.Core.Benchmark.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
+++ b/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
@@ -9,8 +9,8 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.9.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.9.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
在 `EasilyNET.Core.Benchmark.csproj` 文件中，将 `BenchmarkDotNet` 的版本从 `0.15.0` 更新为 `0.15.1`。

在 `EasilyNET.Test.Unit.csproj` 文件中，将 `MSTest.TestAdapter` 和 `MSTest.TestFramework` 的版本从 `3.9.1` 更新为 `3.9.2`。