### PR TITLE
feat: 更新 Swashbuckle.AspNetCore 版本至 9.0.1

### DIFF
--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -29,8 +29,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.1-dev-02306" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
-    <PackageReference Include="System.Management" Version="10.0.0-preview.5.25277.114" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,8 +20,8 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.11" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.1" />
     <!--microsoft asp.net core -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.5.25277.114" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0-preview.5.25277.114" />


### PR DESCRIPTION
在 `WebApi.Test.Unit.csproj` 文件中，`Swashbuckle.AspNetCore` 的版本从 `8.1.4` 更新到 `9.0.1`，同时移除了 `System.Management` 的引用。

在 `Directory.Packages.props` 文件中，`Swashbuckle.AspNetCore.SwaggerGen` 和 `Swashbuckle.AspNetCore.SwaggerUI` 的版本也从 `8.1.4` 更新到 `9.0.1`。