### PR TITLE
fix: 修改过期时间处理逻辑和属性类型

### DIFF
--- a/src/EasilyNET.Mongo.AspNetCore/TimeSeriesCollectionExtensions.cs
+++ b/src/EasilyNET.Mongo.AspNetCore/TimeSeriesCollectionExtensions.cs
@@ -107,8 +107,8 @@ public static class TimeSeriesCollectionExtensions
                 {
                     db.CreateCollection(collectionName, new()
                     {
-                        TimeSeriesOptions = attribute.TimeSeriesOptions, // 设置时序选项
-                        ExpireAfter = attribute.ExpireAfter              // 设置过期时间
+                        TimeSeriesOptions = attribute.TimeSeriesOptions,                                             // 设置时序选项
+                        ExpireAfter = attribute.ExpireAfter < 0 ? null : TimeSpan.FromSeconds(attribute.ExpireAfter) // 设置过期时间
                     });
                     logger?.LogInformation("Successfully created time-series collection: {CollectionName}", collectionName);
                     CollectionCache.Add(collectionName);

--- a/src/EasilyNET.Mongo.Core/Attributes/TimeSeriesCollectionAttribute.cs
+++ b/src/EasilyNET.Mongo.Core/Attributes/TimeSeriesCollectionAttribute.cs
@@ -34,18 +34,10 @@ public sealed class TimeSeriesCollectionAttribute : Attribute
     ///     <para xml:lang="en">Represents the granularity of the time series. If using bucketMaxSpanSeconds, do not set this.</para>
     ///     <para xml:lang="zh">表示时间序列的粒度。如果使用 bucketMaxSpanSeconds，则不设置。</para>
     /// </param>
-    /// <param name="ttl">
-    ///     <para xml:lang="en">
-    ///     Optional. Enable automatic deletion of documents in the time series collection by specifying the number of seconds after
-    ///     which the documents expire. MongoDB automatically deletes expired documents. See Setting TTL for Time Series Collections for more information.
-    ///     </para>
-    ///     <para xml:lang="zh">可选。通过指定文档过期后的秒数，启用自动删除时间序列集合中文档的功能。MongoDB 自动删除过期文档。请参阅设置自动删除时间序列集合 (TTL)，获取更多信息。</para>
-    /// </param>
-    public TimeSeriesCollectionAttribute(string collectionName, string timeField, string metaField, TimeSeriesGranularity granularity = TimeSeriesGranularity.Seconds, TimeSpan? ttl = null)
+    public TimeSeriesCollectionAttribute(string collectionName, string timeField, string metaField, TimeSeriesGranularity granularity = TimeSeriesGranularity.Seconds)
     {
         CollectionName = collectionName;
         TimeSeriesOptions = new(timeField, metaField, granularity, null, null);
-        ExpireAfter = ttl;
     }
 
     /// <summary>
@@ -72,18 +64,10 @@ public sealed class TimeSeriesCollectionAttribute : Attribute
     ///     <para xml:lang="en">The interval used to round the first timestamp when opening a new bucket.</para>
     ///     <para xml:lang="zh">打开新存储桶时用于四舍五入第一个时间戳的间隔。</para>
     /// </param>
-    /// <param name="ttl">
-    ///     <para xml:lang="en">
-    ///     Optional. Enable automatic deletion of documents in the time series collection by specifying the number of seconds after
-    ///     which the documents expire. MongoDB automatically deletes expired documents. See Setting TTL for Time Series Collections for more information.
-    ///     </para>
-    ///     <para xml:lang="zh">可选。通过指定文档过期后的秒数，启用自动删除时间序列集合中文档的功能。MongoDB 自动删除过期文档。请参阅设置自动删除时间序列集合 (TTL)，获取更多信息。</para>
-    /// </param>
-    public TimeSeriesCollectionAttribute(string collectionName, string timeField, string metaField, int bucketMaxSpanSeconds, int bucketRoundingSeconds, TimeSpan? ttl = null)
+    public TimeSeriesCollectionAttribute(string collectionName, string timeField, string metaField, int bucketMaxSpanSeconds, int bucketRoundingSeconds)
     {
         CollectionName = collectionName;
         TimeSeriesOptions = new(timeField, metaField, null, bucketMaxSpanSeconds, bucketRoundingSeconds);
-        ExpireAfter = ttl;
     }
 
     /// <summary>
@@ -105,5 +89,5 @@ public sealed class TimeSeriesCollectionAttribute : Attribute
     ///     </para>
     ///     <para xml:lang="zh">可选。通过指定文档过期后的秒数，启用自动删除时间序列集合中文档的功能。MongoDB 自动删除过期文档。请参阅设置自动删除时间序列集合 (TTL)，获取更多信息。</para>
     /// </summary>
-    public TimeSpan? ExpireAfter { get; set; }
+    public double ExpireAfter { get; set; } = -1;
 }


### PR DESCRIPTION
在 `TimeSeriesCollectionExtensions.cs` 中，更新了 `ExpireAfter` 的赋值逻辑，增加了条件判断以处理负值情况。 在 `TimeSeriesCollectionAttribute.cs` 中，移除了构造函数的 `ttl` 参数，删除了相关文档注释，并将 `ExpireAfter` 的类型从 `TimeSpan?` 改为 `double`，默认值设为 -1，以简化过期时间的处理。