### PR TITLE
feat: 简化模块启用状态检查逻辑

### DIFF
--- a/src/EasilyNET.AutoDependencyInjection/Modules/ModuleApplicationBase.cs
+++ b/src/EasilyNET.AutoDependencyInjection/Modules/ModuleApplicationBase.cs
@@ -125,14 +125,7 @@ internal class ModuleApplicationBase : IModuleApplication
         {
             var module = Expression.Lambda(Expression.New(moduleType)).Compile().DynamicInvoke() as IAppModule;
             ArgumentNullException.ThrowIfNull(module, nameof(moduleType));
-            if (module.GetEnable(new(Services, ServiceProvider)))
-            {
-                return module;
-            }
-#if DEBUG
-            Console.Error.WriteLine($"Module: {moduleType.Name} is disabled");
-#endif
-            return null;
+            return module.GetEnable(new(Services, ServiceProvider)) ? module : null;
         });
     }
 


### PR DESCRIPTION
将模块启用状态的检查逻辑合并到返回语句中，直接依赖于 `module.GetEnable(new(Services, ServiceProvider))` 的结果。这样做减少了代码复杂性，提高了可读性。