### PR TITLE
feat: .NET 10 Preview6

### DIFF
--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0-preview.5.25277.114" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0-preview.6.25358.103" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0-preview.5.25277.114" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0-preview.6.25358.103" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -23,10 +23,10 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.3" />
     <!--microsoft asp.net core -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.5.25277.114" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0-preview.5.25277.114" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.5.25277.114" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.5.25277.114" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.6.25358.103" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0-preview.6.25358.103" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0-preview.6.25358.103" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.6.25358.103" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.7.0" />
   </ItemGroup>
   <!-- 自定义任务来检查 TargetFramework -->

--- a/test/EasilyNET.Test.Unit/DeepCopy/ComplexClassTests.cs
+++ b/test/EasilyNET.Test.Unit/DeepCopy/ComplexClassTests.cs
@@ -1,5 +1,4 @@
 using EasilyNET.Test.Unit.DeepCopy.TestClass;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace EasilyNET.Test.Unit.DeepCopy;
 
@@ -39,11 +38,11 @@ public class ComplexClassTests
         Assert.AreSame(cCopy, cCopy.TupleOfThis.Item3);
 
         // original had nonnull delegates and events but copy has it null (for ExpressionTree copy method)
-        Assert.IsTrue(c.JustDelegate != null);
-        Assert.IsTrue(cCopy.JustDelegate == null);
-        Assert.IsTrue(c.ReadonlyDelegate != null);
-        Assert.IsTrue(cCopy.ReadonlyDelegate == null);
-        Assert.IsTrue(!c.IsJustEventNull);
+        Assert.IsNotNull(c.JustDelegate);
+        Assert.IsNull(cCopy.JustDelegate);
+        Assert.IsNotNull(c.ReadonlyDelegate);
+        Assert.IsNull(cCopy.ReadonlyDelegate);
+        Assert.IsFalse(c.IsJustEventNull);
         Assert.IsTrue(cCopy.IsJustEventNull);
 
         // test of regular dictionary


### PR DESCRIPTION
在 `WebApi.Test.Unit.csproj` 中，更新了 `Microsoft.AspNetCore.Authentication.JwtBearer` 和 `Microsoft.Extensions.Caching.StackExchangeRedis` 的版本。

在 `Directory.Packages.props` 中，更新了多个 `Microsoft.Extensions` 相关的包版本。

在 `ComplexClassTests.cs` 中，移除了对 `Microsoft.VisualStudio.TestTools.UnitTesting` 的引用，并优化了断言语句，提高了代码的可读性和准确性。