### PR TITLE
feat: 升级包版本

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,9 +17,9 @@
   <ItemGroup>
     <PackageVersion Include="Backport.System.Threading.Lock" Version="3.1.4" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.4.1" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
-    <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.20" />
+    <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.21" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.3" />
     <!--microsoft asp.net core -->

--- a/test/EasilyNET.Core.Benchmark/EasilyNET.Core.Benchmark.csproj
+++ b/test/EasilyNET.Core.Benchmark/EasilyNET.Core.Benchmark.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
-		<PackageReference Include="MongoDB.Driver" Version="3.4.0" />
+		<PackageReference Include="MongoDB.Driver" Version="3.4.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
更新 `Directory.Packages.props` 和 `EasilyNET.Core.Benchmark.csproj` 文件中的 `MongoDB.Driver` 包版本，从 `3.4.0` 升级到 `3.4.1`。同时，`Spectre.Console.Json` 包的版本也从 `0.50.1-preview.0.20` 升级到 `0.50.1-preview.0.21`。