### PR TITLE
chore: 更新 PooledMemoryStreamTest.cs 文件引用和断言

### DIFF
--- a/test/EasilyNET.Test.Unit/Essentials/PooledMemoryStreamTest.cs
+++ b/test/EasilyNET.Test.Unit/Essentials/PooledMemoryStreamTest.cs
@@ -1,5 +1,4 @@
 using EasilyNET.Core.Essentials;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace EasilyNET.Test.Unit.Essentials;
 
@@ -33,7 +32,7 @@ public class PooledMemoryStreamTest
     {
         using var stream = new PooledMemoryStream();
         stream.SetLength(100);
-        Assert.AreEqual(100, stream.Length);
+        Assert.HasCount(100, stream);
         stream.Seek(10, SeekOrigin.Begin);
         Assert.AreEqual(10, stream.Position);
         stream.Seek(-5, SeekOrigin.Current);


### PR DESCRIPTION
移除了对 Microsoft.VisualStudio.TestTools.UnitTesting 的引用，添加了对 EasilyNET.Core.Essentials 的引用。 在 SeekAndSetLength_ShouldWorkCorrectly 方法中，将对 stream.Length 的断言修改为 Assert.HasCount(100, stream)。