### PR TITLE
feat: 更新 NuGet 包版本.Net10 Preview 7

### DIFF
--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0-preview.6.25358.103" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0-preview.7.25380.108" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0-preview.6.25358.103" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0-preview.7.25380.108" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.8.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,12 +20,12 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.4.2" />
     <PackageVersion Include="Polly.Core" Version="8.6.2" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
-    <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.24" />
+    <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.25" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.3" />
     <!--microsoft asp.net core -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0-preview.6.25358.103" />
-    <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0-preview.7.25380.108" />
+    <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.8.0" />
   </ItemGroup>
   <!-- 自定义任务来检查 TargetFramework -->
   <PropertyGroup>


### PR DESCRIPTION
在 `WebApi.Test.Unit.csproj` 文件中，更新了以下 NuGet 包的版本：
- `Microsoft.AspNetCore.Authentication.JwtBearer` 从 `10.0.0-preview.6.25358.103` 更新到 `10.0.0-preview.7.25380.108`。
- `Microsoft.Extensions.Caching.StackExchangeRedis` 从 `10.0.0-preview.6.25358.103` 更新到 `10.0.0-preview.7.25380.108`。
- `Microsoft.Extensions.Http.Resilience` 从 `9.7.0` 更新到 `9.8.0`。

在 `Directory.Packages.props` 文件中，更新了以下 NuGet 包的版本：
- `Spectre.Console.Json` 从 `0.50.1-preview.0.24` 更新到 `0.50.1-preview.0.25`。
- `Microsoft.Extensions.DependencyModel` 从 `10.0.0-preview.6.25358.103` 更新到 `10.0.0-preview.7.25380.108`。
- `Microsoft.Extensions.Resilience` 从 `9.7.0` 更新到 `9.8.0`。