### PR TITLE
clear: 清除cpm中未使用的包.

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,7 +18,6 @@
     <PackageVersion Include="Backport.System.Threading.Lock" Version="3.1.4" />
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.7.0-beta.98" />
     <PackageVersion Include="MongoDB.Driver" Version="3.4.2" />
-    <PackageVersion Include="Polly.Core" Version="8.6.2" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageVersion Include="Spectre.Console.Json" Version="0.50.1-preview.0.25" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.3" />


### PR DESCRIPTION
从 `Directory.Packages.props` 文件中移除了 `Polly.Core` 包的版本信息，版本号为 `8.6.2`。