### PR TITLE
chore: 更新 MSTest 适配器和框架版本

### DIFF
--- a/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
+++ b/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
@@ -9,8 +9,8 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.0-preview.25415.9" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.0-preview.25415.9" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.0-preview.25454.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.0-preview.25454.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
在 `EasilyNET.Test.Unit.csproj` 文件中，将 MSTest 的适配器和框架的版本从 `4.0.0-preview.25415.9` 更新为 `4.0.0-preview.25454.2`。