### PR TITLE
chore: 优化 RabbitMQ 客户端连接配置

### DIFF
--- a/src/EasilyNET.RabbitBus.AspNetCore/RabbitServiceExtension.cs
+++ b/src/EasilyNET.RabbitBus.AspNetCore/RabbitServiceExtension.cs
@@ -130,7 +130,8 @@ public static class RabbitServiceExtension
                                                             }
                                                             : throw new InvalidOperationException("Configuration error: Unable to create a connection from the provided configuration."));
             factory.ConsumerDispatchConcurrency = config.ConsumerDispatchConcurrency;
-            factory.RequestedHeartbeat = TimeSpan.FromSeconds(30);
+            factory.RequestedHeartbeat = TimeSpan.FromSeconds(10); // 心跳间隔
+            factory.ContinuationTimeout = TimeSpan.FromSeconds(5); // 请求超时时间
             return factory;
         });
 


### PR DESCRIPTION
缩短了心跳间隔时间，将 `RequestedHeartbeat` 从 30 秒调整为 10 秒，以更快检测连接问题。 新增了 `ContinuationTimeout` 属性，设置为 5 秒，用于定义请求超时时间，提高系统响应性和稳定性。