### PR TITLE
chore: 调整 RabbitMQ 超时配置以提高稳定性

### DIFF
--- a/src/EasilyNET.RabbitBus.AspNetCore/RabbitServiceExtension.cs
+++ b/src/EasilyNET.RabbitBus.AspNetCore/RabbitServiceExtension.cs
@@ -130,8 +130,8 @@ public static class RabbitServiceExtension
                                                             }
                                                             : throw new InvalidOperationException("Configuration error: Unable to create a connection from the provided configuration."));
             factory.ConsumerDispatchConcurrency = config.ConsumerDispatchConcurrency;
-            factory.RequestedHeartbeat = TimeSpan.FromSeconds(10); // 心跳间隔
-            factory.ContinuationTimeout = TimeSpan.FromSeconds(5); // 请求超时时间
+            factory.RequestedHeartbeat = TimeSpan.FromSeconds(10);  // 心跳间隔
+            factory.ContinuationTimeout = TimeSpan.FromSeconds(20); // 请求超时时间 (should be >= 1.5-2x heartbeat)
             return factory;
         });
 


### PR DESCRIPTION
修改了 `RabbitServiceExtension` 类中的配置逻辑：
- 保持 `factory.RequestedHeartbeat` 为 10 秒不变。
- 将 `factory.ContinuationTimeout` 从 5 秒增加到 20 秒。
- 更新注释，明确超时时间应大于等于心跳间隔的 1.5-2 倍。

此次变更旨在优化连接稳定性并提升代码可读性。