### PR TITLE
feat: 新增 EasilyNET.RabbitBus 指标源到 OpenTelemetry 配置

### DIFF
--- a/sample/WebApi.Test.Unit/ServiceModules/OpenTelemetryModule.cs
+++ b/sample/WebApi.Test.Unit/ServiceModules/OpenTelemetryModule.cs
@@ -26,7 +26,7 @@ internal sealed class OpenTelemetryModule : AppModule
                {
                    c.AddRuntimeInstrumentation();
                    c.AddProcessInstrumentation();
-                   c.AddMeter("Microsoft.AspNetCore.Hosting", "Microsoft.AspNetCore.Server.Kestrel", "System.Net.Http", "WebApi.Test.Unit");
+                   c.AddMeter("Microsoft.AspNetCore.Hosting", "Microsoft.AspNetCore.Server.Kestrel", "System.Net.Http", "WebApi.Test.Unit", "EasilyNET.RabbitBus");
                    c.AddOtlpExporter();
                })
                .WithLogging(c => c.AddOtlpExporter())


### PR DESCRIPTION
在 OpenTelemetryModule.cs 文件中，更新了 OpenTelemetry 配置。 在调用 WithMetrics 方法时，c.AddMeter 的参数列表中新增了
"EasilyNET.RabbitBus"，以支持监控该指标源的相关数据。