### PR TITLE
chore: 升级 BenchmarkDotNet 至 0.15.4

### DIFF
--- a/test/EasilyNET.Core.Benchmark/EasilyNET.Core.Benchmark.csproj
+++ b/test/EasilyNET.Core.Benchmark/EasilyNET.Core.Benchmark.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.15.3" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.15.4" />
 		<PackageReference Include="MongoDB.Driver" Version="3.5.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
更新了 `EasilyNET.Core.Benchmark.csproj` 文件中的 `BenchmarkDotNet` 包版本，从 `0.15.3` 升级到了 `0.15.4`，以利用新版本的改进和修复。