### PR TITLE
chore: 升级部分依赖项以引入新功能和修复问题

### DIFF
--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0-rc.1.25451.107" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.9.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0-preview.4" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.13.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.12.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
@@ -29,7 +29,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.1-dev-02306" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,9 +20,9 @@
     <PackageVersion Include="MongoDB.Analyzer" Version="2.0.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.5.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
-    <PackageVersion Include="Spectre.Console.Json" Version="0.51.2-preview.0.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.4" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
+    <PackageVersion Include="Spectre.Console.Json" Version="0.51.2-preview.0.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.6" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.6" />
     <!--microsoft asp.net core -->
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0-rc.1.25451.107" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.9.0" />

--- a/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
+++ b/test/EasilyNET.Test.Unit/EasilyNET.Test.Unit.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.0.0-preview.25465.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.0.0-preview.25465.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.0-preview.25480.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.0-preview.25480.4" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
更新了以下依赖项版本：
- `OpenTelemetry.Exporter.OpenTelemetryProtocol` 和 `OpenTelemetry.Extensions.Hosting` 从 `1.12.0` 升级到 `1.13.0`。
- `Swashbuckle.AspNetCore` 从 `9.0.4` 升级到 `9.0.6`。
- `Spectre.Console.Json` 从 `0.51.2-preview.0.1` 升级到 `0.51.2-preview.0.2`。
- `Swashbuckle.AspNetCore.SwaggerGen` 和 `SwaggerUI` 从 `9.0.4` 升级到 `9.0.6`。
- 测试相关依赖项：
  - `Microsoft.NET.Test.Sdk` 从 `17.14.1` 升级到 `18.0.0`。
  - `MSTest.TestAdapter` 和 `MSTest.TestFramework` 从 `4.0.0-preview.25465.3` 升级到 `4.0.0-preview.25480.4`。

此次升级旨在引入最新功能、修复已知问题并提高兼容性。