### PR TITLE
chore: 优化 SM2 加密库并新增拼写检查规则

### DIFF
--- a/EasilyNET.sln.DotSettings
+++ b/EasilyNET.sln.DotSettings
@@ -18,6 +18,7 @@
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=system_002Eprofile/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=the_0020outstanding_0020confirm/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=waiter_0020outside_0020of_0020the/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=_9700_8981_8865_9F50/@EntryIndexedValue">True</s:Boolean>
 	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=06E0B5326F2C40588720EE747CA86EE5/Field/=table/Order/@EntryValue">0</s:Int64>
 	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=12037952FB3E3C5483C767E0ED2BC2D1/Field/=size/Order/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=12037952FB3E3C5483C767E0ED2BC2D1/Field/=table/Order/@EntryValue">0</s:Int64>


### PR DESCRIPTION
在 EasilyNET.sln.DotSettings 文件中新增了一条语法和拼写检查的异常规则。
在 Sm2Crypt.cs 文件中进行了以下优化：
- 引入 Org.BouncyCastle.Security 命名空间。
- 使用 SecureRandom 替代默认随机数生成器。
- 确保私钥长度为 32 字节，若不足则补齐。
- 为 Encrypt、Decrypt、Signature 和 Verify 方法增加参数空值检查，抛出 ArgumentNullException。
- 优化 ParametersWithID 和私钥初始化逻辑，确保正确性和安全性。