### PR TITLE
feat: 新增 RIPEMD 哈希算法支持

### DIFF
--- a/src/EasilyNET.Security/EasilyNET.Security.csproj
+++ b/src/EasilyNET.Security/EasilyNET.Security.csproj
@@ -16,7 +16,7 @@
 	
   <PropertyGroup>
     <PackageProjectUrl>https://www.nuget.org/packages/EasilyNET.Security</PackageProjectUrl>
-    <Description>一个常用加密算法的封装库,AES,DES,RC4,TripleDES,RSA,SM2,SM3,SM4</Description>
+    <Description>一个常用加密算法的封装库,AES,DES,RC4,TripleDES,RSA,SM2,SM3,SM4,RIPEMD</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EasilyNET.Security/RIPEMD/README.md
+++ b/src/EasilyNET.Security/RIPEMD/README.md
@@ -1,0 +1,151 @@
+# RIPEMD 哈希算法
+
+## 概述
+
+RIPEMD (RACE Integrity Primitives Evaluation Message Digest) 是一系列加密哈希函数,由比利时鲁汶大学开发。本库支持以下 4 种 RIPEMD 变体:
+
+- **RIPEMD-128**: 生成 128 位 (16 字节) 哈希值
+- **RIPEMD-160**: 生成 160 位 (20 字节) 哈希值
+- **RIPEMD-256**: 生成 256 位 (32 字节) 哈希值
+- **RIPEMD-320**: 生成 320 位 (40 字节) 哈希值
+
+## 使用示例
+
+### RIPEMD-128
+
+```csharp
+using EasilyNET.Security;
+
+var data = "Hello World";
+
+// 获取字节数组
+var hashBytes = RipeMD128.Hash(data);
+
+// 获取十六进制字符串 (小写)
+var hexLower = RipeMD128.HashToHex(data);
+
+// 获取十六进制字符串 (大写)
+var hexUpper = RipeMD128.HashToHex(data, upperCase: true);
+
+// 获取 Base64 字符串
+var base64 = RipeMD128.HashToBase64(data);
+
+// 对字节数组进行哈希
+var inputBytes = Encoding.UTF8.GetBytes(data);
+var hashFromBytes = RipeMD128.Hash(inputBytes);
+var hexFromBytes = RipeMD128.HashToHex(inputBytes, upperCase: true);
+var base64FromBytes = RipeMD128.HashToBase64(inputBytes);
+```
+
+### RIPEMD-160
+
+```csharp
+using EasilyNET.Security;
+
+var data = "Hello World";
+
+// 获取字节数组
+var hashBytes = RipeMD160.Hash(data);
+
+// 获取十六进制字符串 (小写)
+var hexLower = RipeMD160.HashToHex(data);
+
+// 获取十六进制字符串 (大写)
+var hexUpper = RipeMD160.HashToHex(data, upperCase: true);
+
+// 获取 Base64 字符串
+var base64 = RipeMD160.HashToBase64(data);
+
+// 对字节数组进行哈希
+var inputBytes = Encoding.UTF8.GetBytes(data);
+var hashFromBytes = RipeMD160.Hash(inputBytes);
+var hexFromBytes = RipeMD160.HashToHex(inputBytes, upperCase: true);
+var base64FromBytes = RipeMD160.HashToBase64(inputBytes);
+```
+
+### RIPEMD-256
+
+```csharp
+using EasilyNET.Security;
+
+var data = "Hello World";
+
+// 获取字节数组
+var hashBytes = RipeMD256.Hash(data);
+
+// 获取十六进制字符串 (小写)
+var hexLower = RipeMD256.HashToHex(data);
+
+// 获取十六进制字符串 (大写)
+var hexUpper = RipeMD256.HashToHex(data, upperCase: true);
+
+// 获取 Base64 字符串
+var base64 = RipeMD256.HashToBase64(data);
+
+// 对字节数组进行哈希
+var inputBytes = Encoding.UTF8.GetBytes(data);
+var hashFromBytes = RipeMD256.Hash(inputBytes);
+var hexFromBytes = RipeMD256.HashToHex(inputBytes, upperCase: true);
+var base64FromBytes = RipeMD256.HashToBase64(inputBytes);
+```
+
+### RIPEMD-320
+
+```csharp
+using EasilyNET.Security;
+
+var data = "Hello World";
+
+// 获取字节数组
+var hashBytes = RipeMD320.Hash(data);
+
+// 获取十六进制字符串 (小写)
+var hexLower = RipeMD320.HashToHex(data);
+
+// 获取十六进制字符串 (大写)
+var hexUpper = RipeMD320.HashToHex(data, upperCase: true);
+
+// 获取 Base64 字符串
+var base64 = RipeMD320.HashToBase64(data);
+
+// 对字节数组进行哈希
+var inputBytes = Encoding.UTF8.GetBytes(data);
+var hashFromBytes = RipeMD320.Hash(inputBytes);
+var hexFromBytes = RipeMD320.HashToHex(inputBytes, upperCase: true);
+var base64FromBytes = RipeMD320.HashToBase64(inputBytes);
+```
+
+## API 说明
+
+每个 RIPEMD 类都提供以下方法:
+
+### Hash 方法
+
+- `Hash(string data)`: 计算字符串的哈希值,返回字节数组
+- `Hash(ReadOnlySpan<byte> data)`: 计算字节数组的哈希值,返回字节数组
+
+### HashToHex 方法
+
+- `HashToHex(string data, bool upperCase = false)`: 计算字符串的哈希值,返回十六进制字符串
+- `HashToHex(ReadOnlySpan<byte> data, bool upperCase = false)`: 计算字节数组的哈希值,返回十六进制字符串
+
+### HashToBase64 方法
+
+- `HashToBase64(string data)`: 计算字符串的哈希值,返回 Base64 字符串
+- `HashToBase64(ReadOnlySpan<byte> data)`: 计算字节数组的哈希值,返回 Base64 字符串
+
+## 输出长度
+
+| 算法       | 位数 | 字节数 | 十六进制字符数 |
+| ---------- | ---- | ------ | -------------- |
+| RIPEMD-128 | 128  | 16     | 32             |
+| RIPEMD-160 | 160  | 20     | 40             |
+| RIPEMD-256 | 256  | 32     | 64             |
+| RIPEMD-320 | 320  | 40     | 80             |
+
+## 注意事项
+
+- 所有方法都使用 UTF-8 编码处理字符串输入
+- 字符串参数不能为 null 或空,否则会抛出 `ArgumentException`
+- 所有实现都基于 BouncyCastle.Cryptography 库
+- 方法使用了 `stackalloc` 进行性能优化

--- a/src/EasilyNET.Security/RIPEMD/RipeMD128.cs
+++ b/src/EasilyNET.Security/RIPEMD/RipeMD128.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using Org.BouncyCastle.Crypto.Digests;
+
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedType.Global
+
+namespace EasilyNET.Security;
+
+/// <summary>
+///     <para xml:lang="en">RIPEMD-128 algorithm</para>
+///     <para xml:lang="zh">RIPEMD-128算法</para>
+///     <para xml:lang="en">A cryptographic hash function producing a 128-bit hash value</para>
+///     <para xml:lang="zh">一种加密哈希函数,生成128位的哈希值</para>
+/// </summary>
+public static class RipeMD128
+{
+    /// <summary>
+    ///     <para xml:lang="en">Gets the RIPEMD-128 hash of a string</para>
+    ///     <para xml:lang="zh">获取字符串的RIPEMD-128哈希值</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-128 hash as a byte array (16 bytes)</para>
+    ///     <para xml:lang="zh">RIPEMD-128哈希值的字节数组(16字节)</para>
+    /// </returns>
+    public static byte[] Hash(string data)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(data);
+        var msg = Encoding.UTF8.GetBytes(data);
+        return Hash(msg);
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Gets the RIPEMD-128 hash of a byte array</para>
+    ///     <para xml:lang="zh">获取字节数组的RIPEMD-128哈希值</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-128 hash as a byte array (16 bytes)</para>
+    ///     <para xml:lang="zh">RIPEMD-128哈希值的字节数组(16字节)</para>
+    /// </returns>
+    public static byte[] Hash(ReadOnlySpan<byte> data)
+    {
+        Span<byte> md = stackalloc byte[16];
+        var digest = new RipeMD128Digest();
+        digest.BlockUpdate(data);
+        digest.DoFinal(md);
+        return md.ToArray();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-128 hash of a string and returns it as a hexadecimal string</para>
+    ///     <para xml:lang="zh">计算字符串的RIPEMD-128哈希并返回十六进制字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <param name="upperCase">
+    ///     <para xml:lang="en">Whether to return uppercase hexadecimal string (default: false)</para>
+    ///     <para xml:lang="zh">是否返回大写的十六进制字符串(默认: false)</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-128 hash as a hexadecimal string (32 characters)</para>
+    ///     <para xml:lang="zh">RIPEMD-128哈希值的十六进制字符串(32个字符)</para>
+    /// </returns>
+    public static string HashToHex(string data, bool upperCase = false)
+    {
+        var hash = Hash(data);
+        var hex = Convert.ToHexString(hash);
+        return upperCase ? hex : hex.ToLowerInvariant();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-128 hash of a byte array and returns it as a hexadecimal string</para>
+    ///     <para xml:lang="zh">计算字节数组的RIPEMD-128哈希并返回十六进制字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <param name="upperCase">
+    ///     <para xml:lang="en">Whether to return uppercase hexadecimal string (default: false)</para>
+    ///     <para xml:lang="zh">是否返回大写的十六进制字符串(默认: false)</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-128 hash as a hexadecimal string (32 characters)</para>
+    ///     <para xml:lang="zh">RIPEMD-128哈希值的十六进制字符串(32个字符)</para>
+    /// </returns>
+    public static string HashToHex(ReadOnlySpan<byte> data, bool upperCase = false)
+    {
+        var hash = Hash(data);
+        var hex = Convert.ToHexString(hash);
+        return upperCase ? hex : hex.ToLowerInvariant();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-128 hash of a string and returns it as a Base64 string</para>
+    ///     <para xml:lang="zh">计算字符串的RIPEMD-128哈希并返回Base64字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-128 hash as a Base64 string</para>
+    ///     <para xml:lang="zh">RIPEMD-128哈希值的Base64字符串</para>
+    /// </returns>
+    public static string HashToBase64(string data)
+    {
+        var hash = Hash(data);
+        return Convert.ToBase64String(hash);
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-128 hash of a byte array and returns it as a Base64 string</para>
+    ///     <para xml:lang="zh">计算字节数组的RIPEMD-128哈希并返回Base64字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-128 hash as a Base64 string</para>
+    ///     <para xml:lang="zh">RIPEMD-128哈希值的Base64字符串</para>
+    /// </returns>
+    public static string HashToBase64(ReadOnlySpan<byte> data)
+    {
+        var hash = Hash(data);
+        return Convert.ToBase64String(hash);
+    }
+}

--- a/src/EasilyNET.Security/RIPEMD/RipeMD160.cs
+++ b/src/EasilyNET.Security/RIPEMD/RipeMD160.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using Org.BouncyCastle.Crypto.Digests;
+
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedType.Global
+
+namespace EasilyNET.Security;
+
+/// <summary>
+///     <para xml:lang="en">RIPEMD-160 algorithm</para>
+///     <para xml:lang="zh">RIPEMD-160算法</para>
+///     <para xml:lang="en">A cryptographic hash function producing a 160-bit hash value</para>
+///     <para xml:lang="zh">一种加密哈希函数,生成160位的哈希值</para>
+/// </summary>
+public static class RipeMD160
+{
+    /// <summary>
+    ///     <para xml:lang="en">Gets the RIPEMD-160 hash of a string</para>
+    ///     <para xml:lang="zh">获取字符串的RIPEMD-160哈希值</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-160 hash as a byte array (20 bytes)</para>
+    ///     <para xml:lang="zh">RIPEMD-160哈希值的字节数组(20字节)</para>
+    /// </returns>
+    public static byte[] Hash(string data)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(data);
+        var msg = Encoding.UTF8.GetBytes(data);
+        return Hash(msg);
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Gets the RIPEMD-160 hash of a byte array</para>
+    ///     <para xml:lang="zh">获取字节数组的RIPEMD-160哈希值</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-160 hash as a byte array (20 bytes)</para>
+    ///     <para xml:lang="zh">RIPEMD-160哈希值的字节数组(20字节)</para>
+    /// </returns>
+    public static byte[] Hash(ReadOnlySpan<byte> data)
+    {
+        Span<byte> md = stackalloc byte[20];
+        var digest = new RipeMD160Digest();
+        digest.BlockUpdate(data);
+        digest.DoFinal(md);
+        return md.ToArray();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-160 hash of a string and returns it as a hexadecimal string</para>
+    ///     <para xml:lang="zh">计算字符串的RIPEMD-160哈希并返回十六进制字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <param name="upperCase">
+    ///     <para xml:lang="en">Whether to return uppercase hexadecimal string (default: false)</para>
+    ///     <para xml:lang="zh">是否返回大写的十六进制字符串(默认: false)</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-160 hash as a hexadecimal string (40 characters)</para>
+    ///     <para xml:lang="zh">RIPEMD-160哈希值的十六进制字符串(40个字符)</para>
+    /// </returns>
+    public static string HashToHex(string data, bool upperCase = false)
+    {
+        var hash = Hash(data);
+        var hex = Convert.ToHexString(hash);
+        return upperCase ? hex : hex.ToLowerInvariant();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-160 hash of a byte array and returns it as a hexadecimal string</para>
+    ///     <para xml:lang="zh">计算字节数组的RIPEMD-160哈希并返回十六进制字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <param name="upperCase">
+    ///     <para xml:lang="en">Whether to return uppercase hexadecimal string (default: false)</para>
+    ///     <para xml:lang="zh">是否返回大写的十六进制字符串(默认: false)</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-160 hash as a hexadecimal string (40 characters)</para>
+    ///     <para xml:lang="zh">RIPEMD-160哈希值的十六进制字符串(40个字符)</para>
+    /// </returns>
+    public static string HashToHex(ReadOnlySpan<byte> data, bool upperCase = false)
+    {
+        var hash = Hash(data);
+        var hex = Convert.ToHexString(hash);
+        return upperCase ? hex : hex.ToLowerInvariant();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-160 hash of a string and returns it as a Base64 string</para>
+    ///     <para xml:lang="zh">计算字符串的RIPEMD-160哈希并返回Base64字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-160 hash as a Base64 string</para>
+    ///     <para xml:lang="zh">RIPEMD-160哈希值的Base64字符串</para>
+    /// </returns>
+    public static string HashToBase64(string data)
+    {
+        var hash = Hash(data);
+        return Convert.ToBase64String(hash);
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-160 hash of a byte array and returns it as a Base64 string</para>
+    ///     <para xml:lang="zh">计算字节数组的RIPEMD-160哈希并返回Base64字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-160 hash as a Base64 string</para>
+    ///     <para xml:lang="zh">RIPEMD-160哈希值的Base64字符串</para>
+    /// </returns>
+    public static string HashToBase64(ReadOnlySpan<byte> data)
+    {
+        var hash = Hash(data);
+        return Convert.ToBase64String(hash);
+    }
+}

--- a/src/EasilyNET.Security/RIPEMD/RipeMD256.cs
+++ b/src/EasilyNET.Security/RIPEMD/RipeMD256.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using Org.BouncyCastle.Crypto.Digests;
+
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedType.Global
+
+namespace EasilyNET.Security;
+
+/// <summary>
+///     <para xml:lang="en">RIPEMD-256 algorithm</para>
+///     <para xml:lang="zh">RIPEMD-256算法</para>
+///     <para xml:lang="en">A cryptographic hash function producing a 256-bit hash value</para>
+///     <para xml:lang="zh">一种加密哈希函数,生成256位的哈希值</para>
+/// </summary>
+public static class RipeMD256
+{
+    /// <summary>
+    ///     <para xml:lang="en">Gets the RIPEMD-256 hash of a string</para>
+    ///     <para xml:lang="zh">获取字符串的RIPEMD-256哈希值</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-256 hash as a byte array (32 bytes)</para>
+    ///     <para xml:lang="zh">RIPEMD-256哈希值的字节数组(32字节)</para>
+    /// </returns>
+    public static byte[] Hash(string data)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(data);
+        var msg = Encoding.UTF8.GetBytes(data);
+        return Hash(msg);
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Gets the RIPEMD-256 hash of a byte array</para>
+    ///     <para xml:lang="zh">获取字节数组的RIPEMD-256哈希值</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-256 hash as a byte array (32 bytes)</para>
+    ///     <para xml:lang="zh">RIPEMD-256哈希值的字节数组(32字节)</para>
+    /// </returns>
+    public static byte[] Hash(ReadOnlySpan<byte> data)
+    {
+        Span<byte> md = stackalloc byte[32];
+        var digest = new RipeMD256Digest();
+        digest.BlockUpdate(data);
+        digest.DoFinal(md);
+        return md.ToArray();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-256 hash of a string and returns it as a hexadecimal string</para>
+    ///     <para xml:lang="zh">计算字符串的RIPEMD-256哈希并返回十六进制字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <param name="upperCase">
+    ///     <para xml:lang="en">Whether to return uppercase hexadecimal string (default: false)</para>
+    ///     <para xml:lang="zh">是否返回大写的十六进制字符串(默认: false)</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-256 hash as a hexadecimal string (64 characters)</para>
+    ///     <para xml:lang="zh">RIPEMD-256哈希值的十六进制字符串(64个字符)</para>
+    /// </returns>
+    public static string HashToHex(string data, bool upperCase = false)
+    {
+        var hash = Hash(data);
+        var hex = Convert.ToHexString(hash);
+        return upperCase ? hex : hex.ToLowerInvariant();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-256 hash of a byte array and returns it as a hexadecimal string</para>
+    ///     <para xml:lang="zh">计算字节数组的RIPEMD-256哈希并返回十六进制字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <param name="upperCase">
+    ///     <para xml:lang="en">Whether to return uppercase hexadecimal string (default: false)</para>
+    ///     <para xml:lang="zh">是否返回大写的十六进制字符串(默认: false)</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-256 hash as a hexadecimal string (64 characters)</para>
+    ///     <para xml:lang="zh">RIPEMD-256哈希值的十六进制字符串(64个字符)</para>
+    /// </returns>
+    public static string HashToHex(ReadOnlySpan<byte> data, bool upperCase = false)
+    {
+        var hash = Hash(data);
+        var hex = Convert.ToHexString(hash);
+        return upperCase ? hex : hex.ToLowerInvariant();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-256 hash of a string and returns it as a Base64 string</para>
+    ///     <para xml:lang="zh">计算字符串的RIPEMD-256哈希并返回Base64字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-256 hash as a Base64 string</para>
+    ///     <para xml:lang="zh">RIPEMD-256哈希值的Base64字符串</para>
+    /// </returns>
+    public static string HashToBase64(string data)
+    {
+        var hash = Hash(data);
+        return Convert.ToBase64String(hash);
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-256 hash of a byte array and returns it as a Base64 string</para>
+    ///     <para xml:lang="zh">计算字节数组的RIPEMD-256哈希并返回Base64字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-256 hash as a Base64 string</para>
+    ///     <para xml:lang="zh">RIPEMD-256哈希值的Base64字符串</para>
+    /// </returns>
+    public static string HashToBase64(ReadOnlySpan<byte> data)
+    {
+        var hash = Hash(data);
+        return Convert.ToBase64String(hash);
+    }
+}

--- a/src/EasilyNET.Security/RIPEMD/RipeMD320.cs
+++ b/src/EasilyNET.Security/RIPEMD/RipeMD320.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using Org.BouncyCastle.Crypto.Digests;
+
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedType.Global
+
+namespace EasilyNET.Security;
+
+/// <summary>
+///     <para xml:lang="en">RIPEMD-320 algorithm</para>
+///     <para xml:lang="zh">RIPEMD-320算法</para>
+///     <para xml:lang="en">A cryptographic hash function producing a 320-bit hash value</para>
+///     <para xml:lang="zh">一种加密哈希函数,生成320位的哈希值</para>
+/// </summary>
+public static class RipeMD320
+{
+    /// <summary>
+    ///     <para xml:lang="en">Gets the RIPEMD-320 hash of a string</para>
+    ///     <para xml:lang="zh">获取字符串的RIPEMD-320哈希值</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-320 hash as a byte array (40 bytes)</para>
+    ///     <para xml:lang="zh">RIPEMD-320哈希值的字节数组(40字节)</para>
+    /// </returns>
+    public static byte[] Hash(string data)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(data);
+        var msg = Encoding.UTF8.GetBytes(data);
+        return Hash(msg);
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Gets the RIPEMD-320 hash of a byte array</para>
+    ///     <para xml:lang="zh">获取字节数组的RIPEMD-320哈希值</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-320 hash as a byte array (40 bytes)</para>
+    ///     <para xml:lang="zh">RIPEMD-320哈希值的字节数组(40字节)</para>
+    /// </returns>
+    public static byte[] Hash(ReadOnlySpan<byte> data)
+    {
+        Span<byte> md = stackalloc byte[40];
+        var digest = new RipeMD320Digest();
+        digest.BlockUpdate(data);
+        digest.DoFinal(md);
+        return md.ToArray();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-320 hash of a string and returns it as a hexadecimal string</para>
+    ///     <para xml:lang="zh">计算字符串的RIPEMD-320哈希并返回十六进制字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <param name="upperCase">
+    ///     <para xml:lang="en">Whether to return uppercase hexadecimal string (default: false)</para>
+    ///     <para xml:lang="zh">是否返回大写的十六进制字符串(默认: false)</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-320 hash as a hexadecimal string (80 characters)</para>
+    ///     <para xml:lang="zh">RIPEMD-320哈希值的十六进制字符串(80个字符)</para>
+    /// </returns>
+    public static string HashToHex(string data, bool upperCase = false)
+    {
+        var hash = Hash(data);
+        var hex = Convert.ToHexString(hash);
+        return upperCase ? hex : hex.ToLowerInvariant();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-320 hash of a byte array and returns it as a hexadecimal string</para>
+    ///     <para xml:lang="zh">计算字节数组的RIPEMD-320哈希并返回十六进制字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <param name="upperCase">
+    ///     <para xml:lang="en">Whether to return uppercase hexadecimal string (default: false)</para>
+    ///     <para xml:lang="zh">是否返回大写的十六进制字符串(默认: false)</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-320 hash as a hexadecimal string (80 characters)</para>
+    ///     <para xml:lang="zh">RIPEMD-320哈希值的十六进制字符串(80个字符)</para>
+    /// </returns>
+    public static string HashToHex(ReadOnlySpan<byte> data, bool upperCase = false)
+    {
+        var hash = Hash(data);
+        var hex = Convert.ToHexString(hash);
+        return upperCase ? hex : hex.ToLowerInvariant();
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-320 hash of a string and returns it as a Base64 string</para>
+    ///     <para xml:lang="zh">计算字符串的RIPEMD-320哈希并返回Base64字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input string</para>
+    ///     <para xml:lang="zh">输入的字符串</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-320 hash as a Base64 string</para>
+    ///     <para xml:lang="zh">RIPEMD-320哈希值的Base64字符串</para>
+    /// </returns>
+    public static string HashToBase64(string data)
+    {
+        var hash = Hash(data);
+        return Convert.ToBase64String(hash);
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">Computes the RIPEMD-320 hash of a byte array and returns it as a Base64 string</para>
+    ///     <para xml:lang="zh">计算字节数组的RIPEMD-320哈希并返回Base64字符串</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The input byte array</para>
+    ///     <para xml:lang="zh">输入的字节数组</para>
+    /// </param>
+    /// <returns>
+    ///     <para xml:lang="en">The RIPEMD-320 hash as a Base64 string</para>
+    ///     <para xml:lang="zh">RIPEMD-320哈希值的Base64字符串</para>
+    /// </returns>
+    public static string HashToBase64(ReadOnlySpan<byte> data)
+    {
+        var hash = Hash(data);
+        return Convert.ToBase64String(hash);
+    }
+}


### PR DESCRIPTION
更新内容：
- 修改 EasilyNET.Security.csproj，描述中新增对 RIPEMD 算法的支持。
- 更新 README.md，新增 RIPEMD-128/160/256/320 的文档说明、使用示例及 API 说明。
- 新增 RipeMD128.cs，支持 RIPEMD-128 哈希算法。
- 新增 RipeMD160.cs，支持 RIPEMD-160 哈希算法。
- 新增 RipeMD256.cs，支持 RIPEMD-256 哈希算法。
- 新增 RipeMD320.cs，支持 RIPEMD-320 哈希算法。
- 所有实现基于 BouncyCastle 库，使用 stackalloc 优化性能。