### PR TITLE
chore: 重命名方法以更准确反映 SM3 哈希功能

### DIFF
--- a/src/EasilyNET.Security/README.md
+++ b/src/EasilyNET.Security/README.md
@@ -95,15 +95,15 @@ private const string data = "Microsoft";
 public void SM3HexString()
 {
     // 方法1: 使用便捷方法直接获取十六进制字符串(小写)
-    var hex = Sm3Signature.SignatureToHex(data);
+    var hex = Sm3Signature.Hash(data);
     hex.Should().Be("1749ce3e4ef7622f1ebabb52078ec86309cabd5a6073c8a0711bf35e19ba51b8");
 
     // 方法2: 使用便捷方法获取大写十六进制字符串
-    var hexUpper = Sm3Signature.SignatureToHex(data, upperCase: true);
+    var hexUpper = Sm3Signature.HashToHex(data, upperCase: true);
     hexUpper.Should().Be("1749CE3E4EF7622F1EBABB52078EC86309CABD5A6073C8A0711BF35E19BA51B8");
 
     // 方法3: 传统方式 - 先获取字节数组再转换
-    var byte_data = Sm3Signature.Signature(data);
+    var byte_data = Sm3Signature.Hash(data);
     var hex2 = Convert.ToHexString(byte_data);
     hex2.ToUpper().Should().Be("1749CE3E4EF7622F1EBABB52078EC86309CABD5A6073C8A0711BF35E19BA51B8");
 }
@@ -114,11 +114,11 @@ public void SM3HexString()
 public void SM3Base64()
 {
     // 方法1: 使用便捷方法直接获取Base64字符串
-    var base64 = Sm3Signature.SignatureToBase64(data);
+    var base64 = Sm3Signature.HashToBase64(data);
     base64.ToUpper().Should().Be("F0NOPK73YI8EURTSB47IYWNKVVPGC8IGCRVZXHM6UBG=");
 
     // 方法2: 传统方式 - 先获取字节数组再转换
-    var byte_data = Sm3Signature.Signature(data);
+    var byte_data = Sm3Signature.Hash(data);
     var base64_2 = Convert.ToBase64String(byte_data);
     base64_2.ToUpper().Should().Be("F0NOPK73YI8EURTSB47IYWNKVVPGC8IGCRVZXHM6UBG=");
 }
@@ -131,11 +131,11 @@ public void SM3FromByteArray()
     var inputBytes = Encoding.UTF8.GetBytes(data);
 
     // 直接获取十六进制字符串
-    var hex = Sm3Signature.SignatureToHex(inputBytes, upperCase: true);
+    var hex = Sm3Signature.HashToHex(inputBytes, upperCase: true);
     hex.Should().Be("1749CE3E4EF7622F1EBABB52078EC86309CABD5A6073C8A0711BF35E19BA51B8");
 
     // 直接获取Base64字符串
-    var base64 = Sm3Signature.SignatureToBase64(inputBytes);
+    var base64 = Sm3Signature.HashToBase64(inputBytes);
     base64.ToUpper().Should().Be("F0NOPK73YI8EURTSB47IYWNKVVPGC8IGCRVZXHM6UBG=");
 }
 ```

--- a/src/EasilyNET.Security/SM3/Sm3Signature.cs
+++ b/src/EasilyNET.Security/SM3/Sm3Signature.cs
@@ -18,8 +18,8 @@ namespace EasilyNET.Security;
 public static class Sm3Signature
 {
     /// <summary>
-    ///     <para xml:lang="en">Gets the SM3 signature of a string (alias for Crypt)</para>
-    ///     <para xml:lang="zh">获取字符串的SM3签名(Crypt的别名)</para>
+    ///     <para xml:lang="en">Gets the SM3 hash of a string (alias for Crypt)</para>
+    ///     <para xml:lang="zh">获取字符串的SM3哈希(Crypt的别名)</para>
     /// </summary>
     /// <param name="data">
     ///     <para xml:lang="en">The input string</para>
@@ -29,16 +29,16 @@ public static class Sm3Signature
     ///     <para xml:lang="en">The SM3 hash as a byte array (32 bytes)</para>
     ///     <para xml:lang="zh">SM3哈希值的字节数组(32字节)</para>
     /// </returns>
-    public static byte[] Signature(string data)
+    public static byte[] Hash(string data)
     {
         ArgumentException.ThrowIfNullOrEmpty(data);
         var msg = Encoding.UTF8.GetBytes(data);
-        return Signature(msg);
+        return Hash(msg);
     }
 
     /// <summary>
-    ///     <para xml:lang="en">Gets the SM3 signature of a byte array (alias for Crypt)</para>
-    ///     <para xml:lang="zh">获取字节数组的SM3签名(Crypt的别名)</para>
+    ///     <para xml:lang="en">Gets the SM3 hash of a byte array (alias for Crypt)</para>
+    ///     <para xml:lang="zh">获取字节数组的SM3哈希(Crypt的别名)</para>
     /// </summary>
     /// <param name="data">
     ///     <para xml:lang="en">The input byte array</para>
@@ -48,7 +48,7 @@ public static class Sm3Signature
     ///     <para xml:lang="en">The SM3 hash as a byte array (32 bytes)</para>
     ///     <para xml:lang="zh">SM3哈希值的字节数组(32字节)</para>
     /// </returns>
-    public static byte[] Signature(ReadOnlySpan<byte> data)
+    public static byte[] Hash(ReadOnlySpan<byte> data)
     {
         Span<byte> md = stackalloc byte[32];
         var sm3 = new SM3Digest();
@@ -73,9 +73,9 @@ public static class Sm3Signature
     ///     <para xml:lang="en">The SM3 hash as a hexadecimal string (64 characters)</para>
     ///     <para xml:lang="zh">SM3哈希值的十六进制字符串(64个字符)</para>
     /// </returns>
-    public static string SignatureToHex(string data, bool upperCase = false)
+    public static string HashToHex(string data, bool upperCase = false)
     {
-        var hash = Signature(data);
+        var hash = Hash(data);
         var hex = Convert.ToHexString(hash);
         return upperCase ? hex : hex.ToLowerInvariant();
     }
@@ -96,9 +96,9 @@ public static class Sm3Signature
     ///     <para xml:lang="en">The SM3 hash as a hexadecimal string (64 characters)</para>
     ///     <para xml:lang="zh">SM3哈希值的十六进制字符串(64个字符)</para>
     /// </returns>
-    public static string SignatureToHex(ReadOnlySpan<byte> data, bool upperCase = false)
+    public static string HashToHex(ReadOnlySpan<byte> data, bool upperCase = false)
     {
-        var hash = Signature(data);
+        var hash = Hash(data);
         var hex = Convert.ToHexString(hash);
         return upperCase ? hex : hex.ToLowerInvariant();
     }
@@ -115,9 +115,9 @@ public static class Sm3Signature
     ///     <para xml:lang="en">The SM3 hash as a Base64 string</para>
     ///     <para xml:lang="zh">SM3哈希值的Base64字符串</para>
     /// </returns>
-    public static string SignatureToBase64(string data)
+    public static string HashToBase64(string data)
     {
-        var hash = Signature(data);
+        var hash = Hash(data);
         return Convert.ToBase64String(hash);
     }
 
@@ -133,9 +133,9 @@ public static class Sm3Signature
     ///     <para xml:lang="en">The SM3 hash as a Base64 string</para>
     ///     <para xml:lang="zh">SM3哈希值的Base64字符串</para>
     /// </returns>
-    public static string SignatureToBase64(ReadOnlySpan<byte> data)
+    public static string HashToBase64(ReadOnlySpan<byte> data)
     {
-        var hash = Signature(data);
+        var hash = Hash(data);
         return Convert.ToBase64String(hash);
     }
 }

--- a/test/EasilyNET.Test.Unit/Security/Sm3Test.cs
+++ b/test/EasilyNET.Test.Unit/Security/Sm3Test.cs
@@ -17,7 +17,7 @@ public class Sm3Test
     [TestMethod]
     public void SM3HexString()
     {
-        var byte_data = Sm3Signature.Signature(data);
+        var byte_data = Sm3Signature.Hash(data);
         var hex = Convert.ToHexString(byte_data);
         hex.ToUpper().ShouldBe("1749CE3E4EF7622F1EBABB52078EC86309CABD5A6073C8A0711BF35E19BA51B8");
     }
@@ -28,7 +28,7 @@ public class Sm3Test
     [TestMethod]
     public void SM3Base64()
     {
-        var byte_data = Sm3Signature.Signature(data);
+        var byte_data = Sm3Signature.Hash(data);
         var base64 = Convert.ToBase64String(byte_data);
         base64.ToUpper().ShouldBe("F0NOPK73YI8EURTSB47IYWNKVVPGC8IGCRVZXHM6UBG=");
     }


### PR DESCRIPTION
将 `Sm3Signature` 类中的方法从 `Signature` 重命名为 `Hash`，并同步更新相关方法（如 `SignatureToHex` -> `HashToHex`，`SignatureToBase64` -> `HashToBase64`）。更新了方法的 XML 注释以反映更改。

更新了 `README.md` 和 `Sm3Test.cs` 中的示例代码和测试代码以使用新的方法名称。所有调用代码均已同步调整，代码逻辑保持不变，仅优化了命名和注释以提高可读性。