### PR TITLE
Dev

### DIFF
--- a/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
+++ b/sample/WebApi.Test.Unit/WebApi.Test.Unit.csproj
@@ -23,8 +23,8 @@
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="11.0.0-preview.2.26159.112" />
 		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.15.0-beta.1" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.0-beta.1" />
@@ -36,7 +36,7 @@
 		<PackageReference Include="Serilog.Sinks.File" Version="8.0.0-nblumhardt-02322" />
 		<PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
 		<PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.1-nblumhardt-02317" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="MongoDB.Analyzer" Version="2.0.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.7.1" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
-    <PackageVersion Include="Spectre.Console.Json" Version="0.54.1-alpha.0.82" />
+    <PackageVersion Include="Spectre.Console.Json" Version="0.54.1-alpha.0.86" />
     <!--microsoft asp.net core -->
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="11.0.0-preview.2.26159.112" />
     <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.4.0" />

--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -423,8 +423,9 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             }
             using var timeoutCts = new CancellationTokenSource(Options.ConnectionTimeout);
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(session.Token, timeoutCts.Token);
-            // ServerUri is guaranteed non-null by Options.Validate() called in ConnectAsync.
-            await session.Socket.ConnectAsync(Options.ServerUri!, linkedCts.Token).ConfigureAwait(false);
+            // Validate ServerUri on every connect/reconnect to avoid NullReferenceException if it was reset.
+            var serverUri = Options.ServerUri ?? throw new InvalidOperationException("WebSocket connection failed because Options.ServerUri is null. Ensure ManagedWebSocketClientOptions.ServerUri is configured before connecting or reconnecting.");
+            await session.Socket.ConnectAsync(serverUri, linkedCts.Token).ConfigureAwait(false);
             await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             WebSocketStateChangedEventArgs? connectedStateChanged;
             try

--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -24,7 +24,9 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
     // Object-lifetime cancellation. Once cancelled, the client is shutting down permanently.
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly Channel<WebSocketMessage> _sendChannel;
-    private volatile bool _disposed;
+
+    // Use int with Interlocked.Exchange to guarantee atomic check-and-set across concurrent callers.
+    private int _disposedFlag;
 
     /// <summary>
     /// 最后发送心跳的时间戳。用于确保远端有足够时间响应心跳。
@@ -86,14 +88,16 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
     /// </summary>
     public WebSocketClientState State => (WebSocketClientState)Volatile.Read(ref _state);
 
+    private bool IsDisposed => Volatile.Read(ref _disposedFlag) != 0;
+
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        if (_disposed)
+        // Guarantee exactly-once disposal even when called concurrently.
+        if (Interlocked.Exchange(ref _disposedFlag, 1) != 0)
         {
             return;
         }
-        _disposed = true;
 
         // 1. Signal all background loops to stop
         await _disposeCts.CancelAsync().ConfigureAwait(false);
@@ -208,11 +212,8 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
     /// </param>
     public async Task ConnectAsync(CancellationToken cancellationToken = default)
     {
-        ObjectDisposedException.ThrowIf(_disposed, typeof(ManagedWebSocketClient));
-        if (Options.ServerUri == null)
-        {
-            throw new InvalidOperationException("ServerUri is not set.");
-        }
+        ObjectDisposedException.ThrowIf(IsDisposed, typeof(ManagedWebSocketClient));
+        Options.Validate();
         WebSocketStateChangedEventArgs? connectingStateChanged;
         await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -248,7 +249,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
     /// </summary>
     public async Task DisconnectAsync()
     {
-        if (_disposed)
+        if (IsDisposed)
         {
             return;
         }
@@ -315,7 +316,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
 
     private async Task SendAsyncInternal(ReadOnlyMemory<byte> message, WebSocketMessageType messageType, bool endOfMessage, byte[]? rentedArray, CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, typeof(ManagedWebSocketClient));
+        ObjectDisposedException.ThrowIf(IsDisposed, typeof(ManagedWebSocketClient));
         if (State != WebSocketClientState.Connected)
         {
             if (rentedArray != null)
@@ -324,7 +325,9 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             }
             throw new InvalidOperationException("Client is not connected.");
         }
-        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        // Only allocate TCS when the caller will actually await it; avoids a heap allocation
+        // per send in fire-and-forget mode (WaitForSendCompletion = false).
+        var tcs = Options.WaitForSendCompletion ? new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously) : null;
         var msg = new WebSocketMessage(message, messageType, endOfMessage, tcs, rentedArray);
         try
         {
@@ -338,13 +341,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             }
             throw;
         }
-
-        // Wait for the message to be sent if we want to ensure delivery order or catch send errors immediately
-        // However, for high performance, we might not want to await the actual send here if we trust the queue.
-        // But the user might expect SendAsync to mean "sent to socket".
-        // Given the requirement for "High performance sending queue", we usually just enqueue.
-        // But if we want to propagate errors, we should await the TCS.
-        if (Options.WaitForSendCompletion)
+        if (tcs is not null)
         {
             await tcs.Task.ConfigureAwait(false);
         }
@@ -426,11 +423,8 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             }
             using var timeoutCts = new CancellationTokenSource(Options.ConnectionTimeout);
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(session.Token, timeoutCts.Token);
-            if (Options.ServerUri == null)
-            {
-                throw new InvalidOperationException("ServerUri is null");
-            }
-            await session.Socket.ConnectAsync(Options.ServerUri, linkedCts.Token).ConfigureAwait(false);
+            // ServerUri is guaranteed non-null by Options.Validate() called in ConnectAsync.
+            await session.Socket.ConnectAsync(Options.ServerUri!, linkedCts.Token).ConfigureAwait(false);
             await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             WebSocketStateChangedEventArgs? connectedStateChanged;
             try
@@ -563,24 +557,23 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
     ///     <para xml:lang="en">
     ///     The heartbeat response is only filtered when:
     ///     1. HeartbeatResponseMessage is not empty (filtering is enabled)
-    ///     2. The message type matches HeartbeatMessageType (prevents filtering business messages with same content but different type)
+    ///     2. The message type matches HeartbeatResponseMessageType (allows response type to differ from send type)
     ///     3. The message content exactly matches HeartbeatResponseMessage
     ///     </para>
     ///     <para xml:lang="zh">
     ///     心跳响应仅在以下条件都满足时才被过滤：
     ///     1. HeartbeatResponseMessage 不为空（启用过滤）
-    ///     2. 消息类型与 HeartbeatMessageType 匹配（防止过滤内容相同但类型不同的业务消息）
+    ///     2. 消息类型与 HeartbeatResponseMessageType 匹配（允许响应类型与发送类型不同）
     ///     3. 消息内容与 HeartbeatResponseMessage 完全匹配
     ///     </para>
     /// </remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool IsHeartbeatResponse(byte[] data, WebSocketMessageType messageType)
     {
         var expectedResponse = Options.HeartbeatResponseMessage;
-        // 只有当消息类型匹配心跳类型且内容匹配时才认为是心跳响应
-        // 这样可以避免误过滤内容恰好是 "pong" 的业务消息（如 Text 类型的 "pong" 不会被过滤，如果心跳类型是 Binary）
+        // 使用独立的 HeartbeatResponseMessageType（而非发送侧的 HeartbeatMessageType），
+        // 支持服务端以不同消息类型（如 Text）响应心跳（如 Binary）的场景。
         return !expectedResponse.IsEmpty &&
-               messageType == Options.HeartbeatMessageType &&
+               messageType == Options.HeartbeatResponseMessageType &&
                data.AsSpan().SequenceEqual(expectedResponse.Span);
     }
 
@@ -591,7 +584,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         {
             while (await _sendChannel.Reader.WaitToReadAsync(token).ConfigureAwait(false))
             {
-                while (_sendChannel.Reader.TryRead(out var message))
+                while (!token.IsCancellationRequested && _sendChannel.Reader.TryRead(out var message))
                 {
                     try
                     {
@@ -603,9 +596,11 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
                         }
                         else
                         {
-                            // If socket is not open, we might want to requeue or fail
-                            // For now, fail the task
-                            message.CompletionSource?.TrySetException(new WebSocketException("WebSocket is not open."));
+                            // Socket is closing (transitioning to reconnect). Stop draining the queue so
+                            // the new SendLoop can pick up remaining messages after reconnection.
+                            // The one message already dequeued cannot be put back, so fail it gracefully.
+                            message.CompletionSource?.TrySetException(new WebSocketException("WebSocket connection closed; message dropped during reconnection."));
+                            return; // let OperationCanceledException / reconnect take over
                         }
                     }
                     catch (Exception ex)
@@ -748,10 +743,15 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             return;
         }
         SetState(WebSocketClientState.Disconnected);
-        OnClosed(new(closeStatus, closeStatusDescription, false));
         if (Options.AutoReconnect && !_disposeCts.IsCancellationRequested)
         {
+            // Do NOT fire OnClosed here — the client is about to attempt reconnection.
+            // OnClosed will be fired only if reconnection ultimately fails (or is cancelled).
             await ReconnectAsync().ConfigureAwait(false);
+        }
+        else
+        {
+            OnClosed(new(closeStatus, closeStatusDescription, false));
         }
     }
 
@@ -1008,7 +1008,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool IsConnectionStartAborted() => _disposed || _disposeCts.IsCancellationRequested || _manualDisconnect;
+    private bool IsConnectionStartAborted() => IsDisposed || _disposeCts.IsCancellationRequested || _manualDisconnect;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool IsShutdownOrDisconnected() => _disposeCts.IsCancellationRequested || _manualDisconnect || State is WebSocketClientState.Disconnected or WebSocketClientState.Disposed;

--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -213,7 +213,6 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
     public async Task ConnectAsync(CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(IsDisposed, typeof(ManagedWebSocketClient));
-        Options.Validate();
         WebSocketStateChangedEventArgs? connectingStateChanged;
         await _connectionLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -222,6 +221,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             {
                 return;
             }
+            Options.Validate();
             _manualDisconnect = false;
             connectingStateChanged = TryUpdateState(WebSocketClientState.Connecting);
             Interlocked.Exchange(ref _reconnectAttempts, 0);

--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -747,7 +747,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         if (Options.AutoReconnect && !_disposeCts.IsCancellationRequested)
         {
             // Do NOT fire OnClosed here — the client is about to attempt reconnection.
-            // OnClosed will be fired only if reconnection ultimately fails (or is cancelled).
+            // OnClosed will be fired only if reconnection ultimately fails; it is not guaranteed to fire when reconnection is cancelled by user code.
             await ReconnectAsync().ConfigureAwait(false);
         }
         else

--- a/src/EasilyNET.Core/WebSocket/WebSocketClientOptions.cs
+++ b/src/EasilyNET.Core/WebSocket/WebSocketClientOptions.cs
@@ -78,20 +78,24 @@ public sealed class WebSocketClientOptions
     ///         <para xml:lang="en">
     ///         This timeout is evaluated after a heartbeat is sent. If no data is received from the server
     ///         within this duration after the heartbeat was sent, the client considers the connection stale and may trigger reconnection.
-    ///         Set to TimeSpan.Zero or a negative value to disable the timeout check.
+    ///         Set to <see cref="TimeSpan.Zero" /> or a negative value to disable the timeout check.
     ///         <br/>
     ///         <b>Important:</b> The timeout check only runs once per heartbeat tick. The actual worst-case detection latency
     ///         is <c>HeartbeatInterval + HeartbeatTimeout</c>, not just <c>HeartbeatTimeout</c>.
-    ///         This value must be less than <see cref="HeartbeatInterval" /> (enforced by <see cref="Validate" />).
+    ///         When <see cref="HeartbeatEnabled" /> is <c>true</c> and <see cref="HeartbeatTimeout" /> is greater than <see cref="TimeSpan.Zero" />,
+    ///         this value must be less than <see cref="HeartbeatInterval" /> (this constraint is enforced by <see cref="Validate" />).
+    ///         When the timeout check is disabled (zero or negative), this relation is recommended but not validated.
     ///         </para>
     ///         <para xml:lang="zh">
     ///         该超时在发送心跳后进行评估。如果在发送心跳后的此时间段内未收到服务器的任何数据，
     ///         客户端将认为连接可能已失活并可能触发重连。
-    ///         设置为 TimeSpan.Zero 或负数可禁用该超时检测。
+    ///         设置为 <see cref="TimeSpan.Zero" /> 或负数可禁用该超时检测。
     ///         <br/>
     ///         <b>注意：</b>超时检测每个心跳周期只运行一次，实际最坏情况下的检测延迟为
     ///         <c>HeartbeatInterval + HeartbeatTimeout</c>，而非仅 <c>HeartbeatTimeout</c>。
-    ///         该值必须小于 <see cref="HeartbeatInterval" />（由 <see cref="Validate" /> 方法强制校验）。
+    ///         当 <see cref="HeartbeatEnabled" /> 为 <c>true</c> 且 <see cref="HeartbeatTimeout" /> 大于 <see cref="TimeSpan.Zero" /> 时，
+    ///         该值必须小于 <see cref="HeartbeatInterval" />（此约束由 <see cref="Validate" /> 方法强制校验）。
+    ///         当超时检测被禁用（零或负数）时，仍然建议保持该值小于 <see cref="HeartbeatInterval" />，但不会进行强制校验。
     ///         </para>
     ///     </remarks>
     /// </summary>

--- a/src/EasilyNET.Core/WebSocket/WebSocketClientOptions.cs
+++ b/src/EasilyNET.Core/WebSocket/WebSocketClientOptions.cs
@@ -79,11 +79,19 @@ public sealed class WebSocketClientOptions
     ///         This timeout is evaluated after a heartbeat is sent. If no data is received from the server
     ///         within this duration after the heartbeat was sent, the client considers the connection stale and may trigger reconnection.
     ///         Set to TimeSpan.Zero or a negative value to disable the timeout check.
+    ///         <br/>
+    ///         <b>Important:</b> The timeout check only runs once per heartbeat tick. The actual worst-case detection latency
+    ///         is <c>HeartbeatInterval + HeartbeatTimeout</c>, not just <c>HeartbeatTimeout</c>.
+    ///         This value must be less than <see cref="HeartbeatInterval" /> (enforced by <see cref="Validate" />).
     ///         </para>
     ///         <para xml:lang="zh">
     ///         该超时在发送心跳后进行评估。如果在发送心跳后的此时间段内未收到服务器的任何数据，
     ///         客户端将认为连接可能已失活并可能触发重连。
     ///         设置为 TimeSpan.Zero 或负数可禁用该超时检测。
+    ///         <br/>
+    ///         <b>注意：</b>超时检测每个心跳周期只运行一次，实际最坏情况下的检测延迟为
+    ///         <c>HeartbeatInterval + HeartbeatTimeout</c>，而非仅 <c>HeartbeatTimeout</c>。
+    ///         该值必须小于 <see cref="HeartbeatInterval" />（由 <see cref="Validate" /> 方法强制校验）。
     ///         </para>
     ///     </remarks>
     /// </summary>
@@ -104,6 +112,22 @@ public sealed class WebSocketClientOptions
     ///     </remarks>
     /// </summary>
     public WebSocketMessageType HeartbeatMessageType { get; set; } = WebSocketMessageType.Binary;
+
+    /// <summary>
+    ///     <para xml:lang="en">Gets or sets the WebSocket message type expected for heartbeat response messages. Default is <see cref="WebSocketMessageType.Binary" />.</para>
+    ///     <para xml:lang="zh">获取或设置心跳响应消息期望的 WebSocket 消息类型。默认为 <see cref="WebSocketMessageType.Binary" />。</para>
+    ///     <remarks>
+    ///         <para xml:lang="en">
+    ///         This allows the heartbeat response type to differ from the heartbeat send type.
+    ///         For example, you may send heartbeats as <see cref="WebSocketMessageType.Binary" /> but the server may respond with <see cref="WebSocketMessageType.Text" />.
+    ///         </para>
+    ///         <para xml:lang="zh">
+    ///         此设置允许心跳响应的消息类型与心跳发送类型不同。
+    ///         例如，可以发送 <see cref="WebSocketMessageType.Binary" /> 类型的心跳，但服务端以 <see cref="WebSocketMessageType.Text" /> 类型响应。
+    ///         </para>
+    ///     </remarks>
+    /// </summary>
+    public WebSocketMessageType HeartbeatResponseMessageType { get; set; } = WebSocketMessageType.Binary;
 
     /// <summary>
     ///     <para xml:lang="en">Gets or sets the factory function to create heartbeat messages. Returns null to send an empty payload.</para>
@@ -221,4 +245,44 @@ public sealed class WebSocketClientOptions
     ///     <para xml:lang="zh">默认心跳消息工厂，返回 "ping" 字节。</para>
     /// </summary>
     private static ReadOnlyMemory<byte> DefaultHeartbeatMessageFactory() => DefaultHeartbeatMessage;
+
+    /// <summary>
+    ///     <para xml:lang="en">Validates the options and throws <see cref="InvalidOperationException" /> if any setting is invalid.</para>
+    ///     <para xml:lang="zh">验证配置选项，如有无效设置则抛出 <see cref="InvalidOperationException" />。</para>
+    /// </summary>
+    internal void Validate()
+    {
+        if (ServerUri is null)
+        {
+            throw new InvalidOperationException("ServerUri must be set before connecting.");
+        }
+        if (ReceiveBufferSize <= 0)
+        {
+            throw new InvalidOperationException($"{nameof(ReceiveBufferSize)} must be greater than zero.");
+        }
+        if (SendQueueCapacity <= 0)
+        {
+            throw new InvalidOperationException($"{nameof(SendQueueCapacity)} must be greater than zero.");
+        }
+        if (ReconnectDelay <= TimeSpan.Zero)
+        {
+            throw new InvalidOperationException($"{nameof(ReconnectDelay)} must be positive.");
+        }
+        if (MaxReconnectAttempts < -1)
+        {
+            throw new InvalidOperationException($"{nameof(MaxReconnectAttempts)} must be -1 (infinite) or a non-negative integer.");
+        }
+        if (ConnectionTimeout <= TimeSpan.Zero)
+        {
+            throw new InvalidOperationException($"{nameof(ConnectionTimeout)} must be positive.");
+        }
+        if (HeartbeatEnabled && HeartbeatInterval <= TimeSpan.Zero)
+        {
+            throw new InvalidOperationException($"{nameof(HeartbeatInterval)} must be positive when heartbeat is enabled.");
+        }
+        if (HeartbeatEnabled && HeartbeatTimeout > TimeSpan.Zero && HeartbeatTimeout >= HeartbeatInterval)
+        {
+            throw new InvalidOperationException($"{nameof(HeartbeatTimeout)} must be less than {nameof(HeartbeatInterval)} to ensure the timeout can be detected within one heartbeat cycle.");
+        }
+    }
 }


### PR DESCRIPTION
- [x] Understand the comment feedback on ConnectAsync validate ordering
- [x] Move `Options.Validate()` inside the lock, after the early-return check for Connected/Connecting state — callers already connected/connecting no longer get spurious exceptions from invalid option values
- [x] Build verified (logic change only; net11.0 SDK not available in sandbox)

<!-- START COPILOT CODING AGENT TIPS -->
---

🔒 GitHub Advanced Security automatically protects Copilot coding agent pull requests. You can protect all pull requests by enabling Advanced Security for your repositories. [Learn more about Advanced Security.](https://gh.io/cca-advanced-security)