### PR TITLE
chore: 优化WebSocket客户端发送通道与事件参数内存管理

### DIFF
--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -632,7 +632,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
                     result.MessageType,
                     true,
                     rentedMessageArray);
-                OnMessageReceived(args); // 事件返回后由客户端统一 Dispose，Data 仅在回调期间有效
+                OnMessageReceived(args); // EN: client disposes buffer after all subscribers return; Data is only valid during callback. / ZH: 事件返回后由客户端统一 Dispose，Data 仅在回调期间有效
             }
         }
         catch (OperationCanceledException) { }

--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -104,7 +104,14 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         var completedTask = await Task.WhenAny(_persistentSendLoopTask, Task.Delay(3000)).ConfigureAwait(false);
         if (completedTask == _persistentSendLoopTask)
         {
-            await _persistentSendLoopTask.ConfigureAwait(false);
+            try
+            {
+                await _persistentSendLoopTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected: the persistent send loop is cancelled by _disposeCts during disposal.
+            }
         }
         else
         {

--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -69,10 +69,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         // Initialize last receive time to "now" so heartbeat timeout doesn't immediately fire
         // before any connection/receive activity happens.
         _lastReceiveTimestamp = Stopwatch.GetTimestamp();
-
-        // 关键修复：持久单一 SendLoop，彻底消除多 reader 竞态
-        _persistentSendLoopTask = Task.Factory.StartNew(PersistentSendLoop, _disposeCts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default)
-                                      .Unwrap();
+        _persistentSendLoopTask = Task.Run(PersistentSendLoop, _disposeCts.Token);
         _ = ObserveBackgroundTask(_persistentSendLoopTask, nameof(PersistentSendLoop));
     }
 
@@ -102,15 +99,14 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         // 1. Signal all background loops to stop
         await _disposeCts.CancelAsync().ConfigureAwait(false);
         await CancelConnectionAsync().ConfigureAwait(false);
-
-        // 等待持久 SendLoop 优雅退出
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         try
         {
-            await Task.WhenAny(_persistentSendLoopTask, Task.Delay(3000)).ConfigureAwait(false);
+            await Task.WhenAny(_persistentSendLoopTask, Task.Delay(TimeSpan.FromSeconds(3), timeoutCts.Token)).ConfigureAwait(false);
         }
-        catch
+        finally
         {
-            /* ignore */
+            await timeoutCts.CancelAsync().ConfigureAwait(false);
         }
 
         // 2. Acquire lock to ensure no concurrent connect/disconnect/reconnect is running.
@@ -123,11 +119,11 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         var disposeLockGracePeriod = NormalizeDisposeLockTimeout(Options.DisposeLockTimeoutGracePeriod);
         try
         {
-            lockAcquired = await _connectionLock.WaitAsync(initialDisposeLockTimeout).ConfigureAwait(false);
+            lockAcquired = await _connectionLock.WaitAsync(initialDisposeLockTimeout, timeoutCts.Token).ConfigureAwait(false);
             if (!lockAcquired && disposeLockGracePeriod > TimeSpan.Zero)
             {
                 Debug.WriteLine($"[ManagedWebSocketClient] Dispose lock timed out after {initialDisposeLockTimeout.TotalSeconds:N1}s — waiting up to an additional {disposeLockGracePeriod.TotalSeconds:N1}s before falling back to best-effort cleanup.");
-                lockAcquired = await _connectionLock.WaitAsync(disposeLockGracePeriod).ConfigureAwait(false);
+                lockAcquired = await _connectionLock.WaitAsync(disposeLockGracePeriod, timeoutCts.Token).ConfigureAwait(false);
             }
             if (!lockAcquired)
             {
@@ -147,7 +143,6 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             {
                 try
                 {
-                    using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
                     await _session.Socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Disposing", timeoutCts.Token).ConfigureAwait(false);
                 }
                 catch (Exception ex)
@@ -486,13 +481,13 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             // Extract token to a local so that CA2025 is not triggered:
             // session is IDisposable, but CancellationToken is a value type copied here before any await.
             var sessionToken = session.Token;
-            // ReSharper disable AccessToDisposedClosure
-            _ = ObserveBackgroundTask(Task.Factory.StartNew(() => ReceiveLoop(session), sessionToken, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap(), nameof(ReceiveLoop));
+            // ReSharper disable once AccessToDisposedClosure
+            _ = ObserveBackgroundTask(Task.Run(() => ReceiveLoop(session), sessionToken), nameof(ReceiveLoop));
             if (Options.HeartbeatEnabled)
             {
-                _ = ObserveBackgroundTask(Task.Factory.StartNew(() => HeartbeatLoop(session), sessionToken, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap(), nameof(HeartbeatLoop));
+                // ReSharper disable once AccessToDisposedClosure
+                _ = ObserveBackgroundTask(Task.Run(() => HeartbeatLoop(session), sessionToken), nameof(HeartbeatLoop));
             }
-            // ReSharper restore AccessToDisposedClosure
         }
         catch (Exception)
         {
@@ -712,7 +707,10 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             {
                 ArrayPool<byte>.Shared.Return(msg.RentedArray);
             }
-            if (msg.CompletionSource is null) continue;
+            if (msg.CompletionSource is null)
+            {
+                continue;
+            }
             if (exception is OperationCanceledException operationCanceledException)
             {
                 msg.CompletionSource.TrySetCanceled(operationCanceledException.CancellationToken);

--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -441,6 +441,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         previousSession?.Dispose();
         try
         {
+            Options.ApplyTo(session.Socket);
             Options.ConfigureWebSocket?.Invoke(session.Socket);
             // Guard against DisconnectAsync / DisposeAsync being called synchronously inside ConfigureWebSocket.
             // In that case the session token is already cancelled and the socket is already disposed,
@@ -520,7 +521,8 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
                     }
                     try
                     {
-                        await currentSession.Socket.SendAsync(message.Data, message.MessageType, message.EndOfMessage, token).ConfigureAwait(false);
+                        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, currentSession.Token);
+                        await currentSession.Socket.SendAsync(message.Data, message.MessageType, message.EndOfMessage, linkedCts.Token).ConfigureAwait(false);
                         message.CompletionSource?.TrySetResult(true);
                     }
                     catch (Exception ex)
@@ -626,11 +628,11 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
                     ArrayPool<byte>.Shared.Return(rentedMessageArray);
                     continue;
                 }
-                var args = new WebSocketMessageReceivedEventArgs(new(rentedMessageArray, 0, messageLength),
+                using var args = new WebSocketMessageReceivedEventArgs(new(rentedMessageArray, 0, messageLength),
                     result.MessageType,
                     true,
                     rentedMessageArray);
-                OnMessageReceived(args); // 事件内部会由调用者 Dispose
+                OnMessageReceived(args); // 事件返回后由客户端统一 Dispose，Data 仅在回调期间有效
             }
         }
         catch (OperationCanceledException) { }
@@ -681,7 +683,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
     ///     3. 消息内容与 HeartbeatResponseMessage 完全匹配
     ///     </para>
     /// </remarks>
-    private bool IsHeartbeatResponse(Span<byte> data, WebSocketMessageType messageType)
+    private bool IsHeartbeatResponse(ReadOnlySpan<byte> data, WebSocketMessageType messageType)
     {
         var expectedResponse = Options.HeartbeatResponseMessage;
         // 使用独立的 HeartbeatResponseMessageType（而非发送侧的 HeartbeatMessageType），
@@ -699,7 +701,13 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             {
                 ArrayPool<byte>.Shared.Return(msg.RentedArray);
             }
-            msg.CompletionSource?.TrySetException(exception);
+            if (msg.CompletionSource is null) continue;
+            if (exception is OperationCanceledException operationCanceledException)
+            {
+                msg.CompletionSource.TrySetCanceled(operationCanceledException.CancellationToken);
+                continue;
+            }
+            msg.CompletionSource.TrySetException(exception);
         }
     }
 

--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -282,7 +282,16 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         timeoutCts.CancelAfter(Options.ConnectionTimeout);
         WebSocketStateChangedEventArgs? closingStateChanged;
         WebSocketStateChangedEventArgs? disconnectedStateChanged;
-        await _connectionLock.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+        try
+        {
+            await _connectionLock.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            // 未能获取锁完成断开操作，还原标志以免永久阻止自动重连
+            _manualDisconnect = false;
+            throw;
+        }
         try
         {
             if (State is WebSocketClientState.Disconnected or WebSocketClientState.Disposed)
@@ -299,7 +308,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
                 {
                     try
                     {
-                        await _session.Socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Client disconnecting", CancellationToken.None).ConfigureAwait(false);
+                        await _session.Socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Client disconnecting", timeoutCts.Token).ConfigureAwait(false);
                     }
                     catch (Exception)
                     {
@@ -494,7 +503,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             session.Dispose();
             if (ReferenceEquals(Volatile.Read(ref _session), session))
             {
-                _session = null;
+                Volatile.Write(ref _session, null);
             }
             throw;
         }
@@ -533,9 +542,11 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
                         {
                             continue;
                         }
-                        await HandleConnectionLoss(currentSession, ex).ConfigureAwait(false);
+                        // 先清空旧队列再触发重连，避免重连成功后 FailPendingSends 误杀用户新消息。
+                        // 使用 break 而非 return，确保外层 WaitToReadAsync 循环存活，重连后可继续消费。
                         FailPendingSends(ex);
-                        return;
+                        await HandleConnectionLoss(currentSession, ex).ConfigureAwait(false);
+                        break;
                     }
                     finally
                     {

--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -23,6 +23,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
 
     // Object-lifetime cancellation. Once cancelled, the client is shutting down permanently.
     private readonly CancellationTokenSource _disposeCts = new();
+    private readonly Task _persistentSendLoopTask; // 持久单一 SendLoop
     private readonly Channel<WebSocketMessage> _sendChannel;
 
     // Use int with Interlocked.Exchange to guarantee atomic check-and-set across concurrent callers.
@@ -68,6 +69,11 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         // Initialize last receive time to "now" so heartbeat timeout doesn't immediately fire
         // before any connection/receive activity happens.
         _lastReceiveTimestamp = Stopwatch.GetTimestamp();
+
+        // 关键修复：持久单一 SendLoop，彻底消除多 reader 竞态
+        _persistentSendLoopTask = Task.Factory.StartNew(PersistentSendLoop, _disposeCts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default)
+                                      .Unwrap();
+        _ = ObserveBackgroundTask(_persistentSendLoopTask, nameof(PersistentSendLoop));
     }
 
     private bool IsDisposed => Volatile.Read(ref _disposedFlag) != 0;
@@ -96,6 +102,16 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         // 1. Signal all background loops to stop
         await _disposeCts.CancelAsync().ConfigureAwait(false);
         await CancelConnectionAsync().ConfigureAwait(false);
+
+        // 等待持久 SendLoop 优雅退出
+        try
+        {
+            await Task.WhenAny(_persistentSendLoopTask, Task.Delay(3000)).ConfigureAwait(false);
+        }
+        catch
+        {
+            /* ignore */
+        }
 
         // 2. Acquire lock to ensure no concurrent connect/disconnect/reconnect is running.
         // Since all CTS tokens are already cancelled, background loops will exit soon and release the lock.
@@ -127,15 +143,12 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             disposedStateChanged = TryUpdateState(WebSocketClientState.Disposed);
 
             // 3. Close socket only while holding the lock to prevent races with concurrent operations.
-            if (lockAcquired && _session is not null)
+            if (lockAcquired && _session?.Socket.State is WebSocketState.Open)
             {
                 try
                 {
-                    if (_session.Socket.State == WebSocketState.Open)
-                    {
-                        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                        await _session.Socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Disposing", timeoutCts.Token).ConfigureAwait(false);
-                    }
+                    using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                    await _session.Socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "Disposing", timeoutCts.Token).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -164,7 +177,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
 
             // 未获取到锁时，对 session 做 best-effort 清理
             // Skip CTS/semaphore disposal to avoid racing with in-flight operations.
-            if (!lockAcquired && _session is not null)
+            else if (!lockAcquired && _session is not null)
             {
                 try
                 {
@@ -260,8 +273,6 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         {
             return;
         }
-        WebSocketStateChangedEventArgs? closingStateChanged;
-        WebSocketStateChangedEventArgs? disconnectedStateChanged;
         // Set _manualDisconnect before waiting on the lock so that any concurrent
         // HandleDisconnectAsync that acquires the lock first sees the flag and
         // skips reconnect / reports initiatedByClient correctly.
@@ -269,6 +280,8 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         // 使用超时防止 ConfigureWebSocket 等回调长时间持有锁导致无限挂起
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutCts.CancelAfter(Options.ConnectionTimeout);
+        WebSocketStateChangedEventArgs? closingStateChanged;
+        WebSocketStateChangedEventArgs? disconnectedStateChanged;
         await _connectionLock.WaitAsync(timeoutCts.Token).ConfigureAwait(false);
         try
         {
@@ -460,13 +473,11 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
             // Mark the connection as alive at the moment we become connected.
             UpdateLastReceiveTimestamp();
 
-            // Start background loops
             // Extract token to a local so that CA2025 is not triggered:
             // session is IDisposable, but CancellationToken is a value type copied here before any await.
             var sessionToken = session.Token;
             // ReSharper disable AccessToDisposedClosure
             _ = ObserveBackgroundTask(Task.Factory.StartNew(() => ReceiveLoop(session), sessionToken, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap(), nameof(ReceiveLoop));
-            _ = ObserveBackgroundTask(Task.Factory.StartNew(() => SendLoop(session), sessionToken, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap(), nameof(SendLoop));
             if (Options.HeartbeatEnabled)
             {
                 _ = ObserveBackgroundTask(Task.Factory.StartNew(() => HeartbeatLoop(session), sessionToken, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap(), nameof(HeartbeatLoop));
@@ -488,12 +499,65 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         }
     }
 
+    private async Task PersistentSendLoop()
+    {
+        var token = _disposeCts.Token;
+        try
+        {
+            while (await _sendChannel.Reader.WaitToReadAsync(token).ConfigureAwait(false))
+            {
+                while (!token.IsCancellationRequested && _sendChannel.Reader.TryRead(out var message))
+                {
+                    var currentSession = Volatile.Read(ref _session);
+                    if (currentSession is null || !IsSessionOpen(currentSession))
+                    {
+                        message.CompletionSource?.TrySetException(new InvalidOperationException("WebSocket connection is not open."));
+                        if (message.RentedArray != null)
+                        {
+                            ArrayPool<byte>.Shared.Return(message.RentedArray);
+                        }
+                        continue;
+                    }
+                    try
+                    {
+                        await currentSession.Socket.SendAsync(message.Data, message.MessageType, message.EndOfMessage, token).ConfigureAwait(false);
+                        message.CompletionSource?.TrySetResult(true);
+                    }
+                    catch (Exception ex)
+                    {
+                        message.CompletionSource?.TrySetException(ex);
+                        OnError(new(ex, "PersistentSendLoop"));
+                        if (IsSessionOpen(currentSession))
+                        {
+                            continue;
+                        }
+                        await HandleConnectionLoss(currentSession, ex).ConfigureAwait(false);
+                        FailPendingSends(ex);
+                        return;
+                    }
+                    finally
+                    {
+                        if (message.RentedArray != null)
+                        {
+                            ArrayPool<byte>.Shared.Return(message.RentedArray);
+                        }
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            OnError(new(ex, "PersistentSendLoop"));
+            FailPendingSends(ex);
+        }
+    }
+
     private async Task ReceiveLoop(ConnectionSession session)
     {
-        // 从 ArrayPool 租借接收缓冲区,避免每次循环分配
         var buffer = ArrayPool<byte>.Shared.Rent(Options.ReceiveBufferSize);
         var token = session.Token;
-        var maxMessageSize = Options.MaxMessageSize;
+        var maxSize = Options.MaxMessageSize;
         try
         {
             while (!token.IsCancellationRequested && IsSessionOpen(session))
@@ -504,85 +568,72 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
                     await HandleServerClose(session, session.Socket.CloseStatus, session.Socket.CloseStatusDescription).ConfigureAwait(false);
                     return;
                 }
-                byte[] data;
+                byte[] rentedMessageArray;
+                int messageLength;
                 if (result.EndOfMessage)
                 {
-                    // 单帧消息快速路径：直接从缓冲区复制，跳过 PooledMemoryStream
-                    // Pre-check before allocating to avoid memory exhaustion
-                    if (maxMessageSize > 0 && result.Count > maxMessageSize)
+                    // 单帧快速路径
+                    if (maxSize > 0 && result.Count > maxSize)
                     {
-                        var ex = new InvalidOperationException($"WebSocket message size ({result.Count} bytes) exceeded maximum allowed size ({maxMessageSize} bytes).");
-                        OnError(new(ex, "ReceiveLoop message size limit exceeded"));
+                        var ex = new InvalidOperationException($"Message size ({result.Count}) exceeded MaxMessageSize ({maxSize}).");
+                        OnError(new(ex, "ReceiveLoop"));
                         await HandleConnectionLoss(session, ex).ConfigureAwait(false);
                         return;
                     }
-                    data = new byte[result.Count];
-                    buffer.AsSpan(0, result.Count).CopyTo(data);
+                    rentedMessageArray = ArrayPool<byte>.Shared.Rent(result.Count);
+                    messageLength = result.Count;
+                    buffer.AsSpan(0, result.Count).CopyTo(rentedMessageArray);
                 }
                 else
                 {
-                    // 多帧消息：使用 PooledMemoryStream 拼接
+                    // 多帧路径（优化：仅一次最终分配）
                     await using var ms = new PooledMemoryStream();
-                    if (result.Count > 0)
-                    {
-                        // Pre-check first frame before writing
-                        if (maxMessageSize > 0 && result.Count > maxMessageSize)
-                        {
-                            var ex = new InvalidOperationException($"WebSocket message size ({result.Count} bytes) exceeded maximum allowed size ({maxMessageSize} bytes).");
-                            OnError(new(ex, "ReceiveLoop message size limit exceeded"));
-                            await HandleConnectionLoss(session, ex).ConfigureAwait(false);
-                            return;
-                        }
-                        ms.Write(buffer.AsSpan(0, result.Count));
-                    }
                     do
                     {
-                        result = await session.Socket.ReceiveAsync(buffer.AsMemory(0, Options.ReceiveBufferSize), token).ConfigureAwait(false);
-                        if (result.MessageType == WebSocketMessageType.Close)
+                        if (result.Count > 0)
                         {
-                            await HandleServerClose(session, session.Socket.CloseStatus, session.Socket.CloseStatusDescription).ConfigureAwait(false);
-                            return;
+                            if (maxSize > 0 && (ulong)ms.Length + (ulong)result.Count > (ulong)maxSize)
+                            {
+                                var ex = new InvalidOperationException($"Message size exceeded MaxMessageSize ({maxSize}).");
+                                OnError(new(ex, "ReceiveLoop"));
+                                await HandleConnectionLoss(session, ex).ConfigureAwait(false);
+                                return;
+                            }
+                            ms.Write(buffer.AsSpan(0, result.Count));
                         }
-                        if (result.Count <= 0)
+                        if (result.EndOfMessage)
+                        {
+                            break;
+                        }
+                        result = await session.Socket.ReceiveAsync(buffer.AsMemory(0, Options.ReceiveBufferSize), token).ConfigureAwait(false);
+                        if (result.MessageType != WebSocketMessageType.Close)
                         {
                             continue;
                         }
-                        // Pre-check: accumulated + incoming before writing, not after
-                        if (maxMessageSize > 0 && (ulong)ms.Length + (ulong)result.Count > (ulong)maxMessageSize)
-                        {
-                            var ex = new InvalidOperationException($"WebSocket message size ({ms.Length + result.Count} bytes) exceeded maximum allowed size ({maxMessageSize} bytes).");
-                            OnError(new(ex, "ReceiveLoop message size limit exceeded"));
-                            await HandleConnectionLoss(session, ex).ConfigureAwait(false);
-                            return;
-                        }
-                        ms.Write(buffer.AsSpan(0, result.Count));
-                    } while (!result.EndOfMessage);
-                    var segment = ms.ToArraySegment();
-                    data = new byte[segment.Count];
-                    Buffer.BlockCopy(segment.Array!, segment.Offset, data, 0, segment.Count);
+                        await HandleServerClose(session, session.Socket.CloseStatus, session.Socket.CloseStatusDescription).ConfigureAwait(false);
+                        return;
+                    } while (true);
+                    var finalLength = (int)ms.Length;
+                    rentedMessageArray = ArrayPool<byte>.Shared.Rent(finalLength);
+                    messageLength = finalLength;
+                    ms.GetSpan().CopyTo(rentedMessageArray);
                 }
-
-                // Any successfully received message indicates the connection is alive.
                 UpdateLastReceiveTimestamp();
 
-                // 检查是否为心跳响应消息（pong），如果是则不触发 MessageReceived 事件
-                // 只有当消息类型与心跳类型匹配且内容匹配时才过滤，避免误过滤业务消息
-                if (IsHeartbeatResponse(data, result.MessageType))
+                // 心跳响应过滤
+                if (IsHeartbeatResponse(rentedMessageArray.AsSpan(0, messageLength), result.MessageType))
                 {
+                    ArrayPool<byte>.Shared.Return(rentedMessageArray);
                     continue;
                 }
-                OnMessageReceived(new(data, result.MessageType, true));
+                var args = new WebSocketMessageReceivedEventArgs(new(rentedMessageArray, 0, messageLength),
+                    result.MessageType,
+                    true,
+                    rentedMessageArray);
+                OnMessageReceived(args); // 事件内部会由调用者 Dispose
             }
         }
-        catch (OperationCanceledException)
-        {
-            // Normal cancellation
-        }
-        catch (WebSocketException ex) when (ex.WebSocketErrorCode == WebSocketError.ConnectionClosedPrematurely)
-        {
-            // 连接被远端关闭,不视为错误
-            await HandleConnectionLoss(session, ex).ConfigureAwait(false);
-        }
+        catch (OperationCanceledException) { }
         catch (Exception ex)
         {
             OnError(new(ex, "ReceiveLoop"));
@@ -630,102 +681,25 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
     ///     3. 消息内容与 HeartbeatResponseMessage 完全匹配
     ///     </para>
     /// </remarks>
-    private bool IsHeartbeatResponse(byte[] data, WebSocketMessageType messageType)
+    private bool IsHeartbeatResponse(Span<byte> data, WebSocketMessageType messageType)
     {
         var expectedResponse = Options.HeartbeatResponseMessage;
         // 使用独立的 HeartbeatResponseMessageType（而非发送侧的 HeartbeatMessageType），
         // 支持服务端以不同消息类型（如 Text）响应心跳（如 Binary）的场景。
         return !expectedResponse.IsEmpty &&
                messageType == Options.HeartbeatResponseMessageType &&
-               data.AsSpan().SequenceEqual(expectedResponse.Span);
-    }
-
-    private async Task SendLoop(ConnectionSession session)
-    {
-        var token = session.Token;
-        try
-        {
-            while (await _sendChannel.Reader.WaitToReadAsync(token).ConfigureAwait(false))
-            {
-                while (!token.IsCancellationRequested && _sendChannel.Reader.TryRead(out var message))
-                {
-                    try
-                    {
-                        if (IsSessionOpen(session))
-                        {
-                            // SendLoop 是唯一的发送者，无需加锁
-                            await session.Socket.SendAsync(message.Data, message.MessageType, message.EndOfMessage, token).ConfigureAwait(false);
-                            message.CompletionSource?.TrySetResult(true);
-                        }
-                        else
-                        {
-                            // Socket is closing (transitioning to reconnect). Stop draining the queue so
-                            // the new SendLoop can pick up remaining messages after reconnection.
-                            // The one message already dequeued cannot be put back, so fail it gracefully.
-                            message.CompletionSource?.TrySetException(new WebSocketException("WebSocket connection closed; message dropped during reconnection."));
-                            return; // let OperationCanceledException / reconnect take over
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        message.CompletionSource?.TrySetException(ex);
-                        OnError(new(ex, "SendLoop processing message"));
-                        // If send fails, it might be a connection issue
-                        if (IsSessionOpen(session))
-                        {
-                            continue;
-                        }
-                        await HandleConnectionLoss(session, ex).ConfigureAwait(false);
-                        FailPendingSends(ex);
-                        return; // Exit loop, let reconnection handle restart
-                    }
-                    finally
-                    {
-                        if (message.RentedArray != null)
-                        {
-                            ArrayPool<byte>.Shared.Return(message.RentedArray);
-                        }
-                    }
-                }
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // Distinguish between reconnect-triggered cancellation (new SendLoop will take over)
-            // and disconnect/dispose cancellation (pending sends must be completed to avoid callers hanging).
-            if (IsShutdownOrDisconnected())
-            {
-                FailPendingSends(new OperationCanceledException("SendLoop cancelled due to disconnect or dispose."));
-            }
-            // Otherwise (reconnecting) — do NOT drain the queue; a new SendLoop will take over after reconnect
-        }
-        catch (Exception ex)
-        {
-            OnError(new(ex, "SendLoop"));
-            FailPendingSends(ex);
-        }
+               data.SequenceEqual(expectedResponse.Span);
     }
 
     private void FailPendingSends(Exception exception)
     {
-        while (_sendChannel.Reader.TryRead(out var pendingMessage))
+        while (_sendChannel.Reader.TryRead(out var msg))
         {
-            if (pendingMessage.RentedArray != null)
+            if (msg.RentedArray is not null)
             {
-                ArrayPool<byte>.Shared.Return(pendingMessage.RentedArray);
+                ArrayPool<byte>.Shared.Return(msg.RentedArray);
             }
-            if (pendingMessage.CompletionSource is null)
-            {
-                continue;
-            }
-            if (exception is OperationCanceledException)
-            {
-                pendingMessage.CompletionSource.TrySetCanceled();
-            }
-            else
-            {
-                pendingMessage.CompletionSource.TrySetException(exception);
-            }
+            msg.CompletionSource?.TrySetException(exception);
         }
     }
 
@@ -1121,9 +1095,6 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool IsConnectionStartAborted() => IsDisposed || _disposeCts.IsCancellationRequested || _manualDisconnect;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool IsShutdownOrDisconnected() => _disposeCts.IsCancellationRequested || _manualDisconnect || State is WebSocketClientState.Disconnected or WebSocketClientState.Disposed;
 
     private WebSocketStateChangedEventArgs? TryUpdateState(WebSocketClientState newState)
     {

--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -104,13 +104,14 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
         await CancelConnectionAsync().ConfigureAwait(false);
 
         // 等待持久 SendLoop 优雅退出
-        try
+        var completedTask = await Task.WhenAny(_persistentSendLoopTask, Task.Delay(3000)).ConfigureAwait(false);
+        if (completedTask == _persistentSendLoopTask)
         {
-            await Task.WhenAny(_persistentSendLoopTask, Task.Delay(3000)).ConfigureAwait(false);
+            await _persistentSendLoopTask.ConfigureAwait(false);
         }
-        catch
+        else
         {
-            /* ignore */
+            Debug.WriteLine("[ManagedWebSocketClient] Persistent SendLoop did not exit within 3 seconds during disposal; continuing with best-effort cleanup.");
         }
 
         // 2. Acquire lock to ensure no concurrent connect/disconnect/reconnect is running.

--- a/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
+++ b/src/EasilyNET.Core/WebSocket/ManagedWebSocketClient.cs
@@ -531,8 +531,7 @@ public sealed class ManagedWebSocketClient : IAsyncDisposable
                     }
                     try
                     {
-                        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, currentSession.Token);
-                        await currentSession.Socket.SendAsync(message.Data, message.MessageType, message.EndOfMessage, linkedCts.Token).ConfigureAwait(false);
+                        await currentSession.Socket.SendAsync(message.Data, message.MessageType, message.EndOfMessage, currentSession.Token).ConfigureAwait(false);
                         message.CompletionSource?.TrySetResult(true);
                     }
                     catch (Exception ex)

--- a/src/EasilyNET.Core/WebSocket/WebSocketClientOptions.cs
+++ b/src/EasilyNET.Core/WebSocket/WebSocketClientOptions.cs
@@ -55,8 +55,8 @@ public sealed class WebSocketClientOptions
     public TimeSpan MaxReconnectDelay { get; init; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    ///     <para xml:lang="en">Gets or sets the underlying TCP Keep-Alive interval.</para>
-    ///     <para xml:lang="zh">获取或设置底层 TCP Keep-Alive 间隔。</para>
+    ///     <para xml:lang="en">Gets or sets the WebSocket keep-alive (PING) interval.</para>
+    ///     <para xml:lang="zh">获取或设置 WebSocket 保活（PING）间隔。</para>
     /// </summary>
     public TimeSpan? KeepAliveInterval { get; init; }
 

--- a/src/EasilyNET.Core/WebSocket/WebSocketClientOptions.cs
+++ b/src/EasilyNET.Core/WebSocket/WebSocketClientOptions.cs
@@ -55,6 +55,18 @@ public sealed class WebSocketClientOptions
     public TimeSpan MaxReconnectDelay { get; init; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
+    ///     <para xml:lang="en">Gets or sets the underlying TCP Keep-Alive interval.</para>
+    ///     <para xml:lang="zh">获取或设置底层 TCP Keep-Alive 间隔。</para>
+    /// </summary>
+    public TimeSpan? KeepAliveInterval { get; init; }
+
+    /// <summary>
+    ///     <para xml:lang="en">Gets or sets the requested SubProtocols.</para>
+    ///     <para xml:lang="zh">请求的 SubProtocol 列表</para>
+    /// </summary>
+    public IReadOnlyList<string>? RequestedSubProtocols { get; init; }
+
+    /// <summary>
     ///     <para xml:lang="en">
     ///     Gets or sets whether application-level heartbeat is enabled. Requires server-side cooperation to recognize and handle heartbeat payloads. The
     ///     server may optionally respond (for example, with a PONG or any other message type); any message received from the server is treated as activity
@@ -79,7 +91,7 @@ public sealed class WebSocketClientOptions
     ///         This timeout is evaluated after a heartbeat is sent. If no data is received from the server
     ///         within this duration after the heartbeat was sent, the client considers the connection stale and may trigger reconnection.
     ///         Set to <see cref="TimeSpan.Zero" /> or a negative value to disable the timeout check.
-    ///         <br/>
+    ///         <br />
     ///         <b>Important:</b> The timeout check only runs once per heartbeat tick. The actual worst-case detection latency
     ///         is <c>HeartbeatInterval + HeartbeatTimeout</c>, not just <c>HeartbeatTimeout</c>.
     ///         When <see cref="HeartbeatEnabled" /> is <c>true</c> and <see cref="HeartbeatTimeout" /> is greater than <see cref="TimeSpan.Zero" />,
@@ -90,7 +102,7 @@ public sealed class WebSocketClientOptions
     ///         该超时在发送心跳后进行评估。如果在发送心跳后的此时间段内未收到服务器的任何数据，
     ///         客户端将认为连接可能已失活并可能触发重连。
     ///         设置为 <see cref="TimeSpan.Zero" /> 或负数可禁用该超时检测。
-    ///         <br/>
+    ///         <br />
     ///         <b>注意：</b>超时检测每个心跳周期只运行一次，实际最坏情况下的检测延迟为
     ///         <c>HeartbeatInterval + HeartbeatTimeout</c>，而非仅 <c>HeartbeatTimeout</c>。
     ///         当 <see cref="HeartbeatEnabled" /> 为 <c>true</c> 且 <see cref="HeartbeatTimeout" /> 大于 <see cref="TimeSpan.Zero" /> 时，
@@ -118,12 +130,16 @@ public sealed class WebSocketClientOptions
     public WebSocketMessageType HeartbeatMessageType { get; init; } = WebSocketMessageType.Binary;
 
     /// <summary>
-    ///     <para xml:lang="en">Gets or sets the WebSocket message type expected for heartbeat response messages. Default is <see cref="WebSocketMessageType.Binary" />.</para>
+    ///     <para xml:lang="en">
+    ///     Gets or sets the WebSocket message type expected for heartbeat response messages. Default is
+    ///     <see cref="WebSocketMessageType.Binary" />.
+    ///     </para>
     ///     <para xml:lang="zh">获取或设置心跳响应消息期望的 WebSocket 消息类型。默认为 <see cref="WebSocketMessageType.Binary" />。</para>
     ///     <remarks>
     ///         <para xml:lang="en">
     ///         This allows the heartbeat response type to differ from the heartbeat send type.
-    ///         For example, you may send heartbeats as <see cref="WebSocketMessageType.Binary" /> but the server may respond with <see cref="WebSocketMessageType.Text" />.
+    ///         For example, you may send heartbeats as <see cref="WebSocketMessageType.Binary" /> but the server may respond with
+    ///         <see cref="WebSocketMessageType.Text" />.
     ///         </para>
     ///         <para xml:lang="zh">
     ///         此设置允许心跳响应的消息类型与心跳发送类型不同。
@@ -174,12 +190,16 @@ public sealed class WebSocketClientOptions
     public TimeSpan ConnectionTimeout { get; init; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
-    ///     <para xml:lang="en">Gets or sets the initial wait timeout for acquiring the internal connection lock during <see cref="ManagedWebSocketClient.DisposeAsync" />. Default is 5 seconds.</para>
+    ///     <para xml:lang="en">
+    ///     Gets or sets the initial wait timeout for acquiring the internal connection lock during
+    ///     <see cref="ManagedWebSocketClient.DisposeAsync" />. Default is 5 seconds.
+    ///     </para>
     ///     <para xml:lang="zh">获取或设置 <see cref="ManagedWebSocketClient.DisposeAsync" /> 期间首次等待内部连接锁的超时时间。默认为 5 秒。</para>
     /// </summary>
     /// <remarks>
     ///     <para xml:lang="en">
-    ///     If the lock is not acquired within this timeout, the client will perform one additional bounded wait using <see cref="DisposeLockTimeoutGracePeriod" />.
+    ///     If the lock is not acquired within this timeout, the client will perform one additional bounded wait using
+    ///     <see cref="DisposeLockTimeoutGracePeriod" />.
     ///     </para>
     ///     <para xml:lang="zh">
     ///     如果在此时间内未获取到锁，客户端会再使用 <see cref="DisposeLockTimeoutGracePeriod" /> 进行一次有界等待。
@@ -301,6 +321,10 @@ public sealed class WebSocketClientOptions
         if (HeartbeatEnabled && HeartbeatTimeout > TimeSpan.Zero && HeartbeatTimeout >= HeartbeatInterval)
         {
             throw new InvalidOperationException($"{nameof(HeartbeatTimeout)} must be less than {nameof(HeartbeatInterval)} to ensure the timeout can be detected within one heartbeat cycle.");
+        }
+        if (KeepAliveInterval is { } interval && interval < TimeSpan.Zero)
+        {
+            throw new InvalidOperationException($"{nameof(KeepAliveInterval)} must be null or non-negative.");
         }
     }
 }

--- a/src/EasilyNET.Core/WebSocket/WebSocketClientOptions.cs
+++ b/src/EasilyNET.Core/WebSocket/WebSocketClientOptions.cs
@@ -285,6 +285,40 @@ public sealed class WebSocketClientOptions
     private static ReadOnlyMemory<byte> DefaultHeartbeatMessageFactory() => DefaultHeartbeatMessage;
 
     /// <summary>
+    ///     <para xml:lang="en">Applies transport-level options to the specified <see cref="ClientWebSocket" /> instance.</para>
+    ///     <para xml:lang="zh">将传输层相关配置应用到指定的 <see cref="ClientWebSocket" /> 实例。</para>
+    /// </summary>
+    /// <param name="clientWebSocket">
+    ///     <para xml:lang="en">The target client WebSocket.</para>
+    ///     <para xml:lang="zh">目标客户端 WebSocket。</para>
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    ///     <para xml:lang="en">Thrown when <paramref name="clientWebSocket" /> is <c>null</c>.</para>
+    ///     <para xml:lang="zh">当 <paramref name="clientWebSocket" /> 为 <c>null</c> 时抛出。</para>
+    /// </exception>
+    internal void ApplyTo(ClientWebSocket clientWebSocket)
+    {
+        ArgumentNullException.ThrowIfNull(clientWebSocket);
+        if (KeepAliveInterval is { } keepAliveInterval)
+        {
+            clientWebSocket.Options.KeepAliveInterval = keepAliveInterval;
+        }
+        if (RequestedSubProtocols is not { Count: > 0 })
+        {
+            return;
+        }
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var subProtocol in RequestedSubProtocols)
+        {
+            if (string.IsNullOrWhiteSpace(subProtocol) || !seen.Add(subProtocol))
+            {
+                continue;
+            }
+            clientWebSocket.Options.AddSubProtocol(subProtocol);
+        }
+    }
+
+    /// <summary>
     ///     <para xml:lang="en">Validates the options and throws <see cref="InvalidOperationException" /> if any setting is invalid.</para>
     ///     <para xml:lang="zh">验证配置选项，如有无效设置则抛出 <see cref="InvalidOperationException" />。</para>
     /// </summary>

--- a/src/EasilyNET.Core/WebSocket/WebSocketEventArgs.cs
+++ b/src/EasilyNET.Core/WebSocket/WebSocketEventArgs.cs
@@ -38,27 +38,65 @@ public sealed class WebSocketStateChangedEventArgs(WebSocketClientState previous
 ///     在所有事件订阅者返回后统一释放——<see cref="Data" /> 仅在事件回调期间有效，处理函数返回后不得存储或访问。
 ///     </para>
 /// </summary>
-public sealed class WebSocketMessageReceivedEventArgs(ReadOnlyMemory<byte> data, WebSocketMessageType messageType, bool endOfMessage, byte[]? rentedArray = null) : EventArgs, IDisposable
+public sealed class WebSocketMessageReceivedEventArgs : EventArgs, IDisposable
 {
-    private byte[]? _rentedArray = rentedArray;
+    private byte[]? _rentedArray;
+
+    /// <summary>
+    ///     <para xml:lang="en">Initializes a new instance of the <see cref="WebSocketMessageReceivedEventArgs" /> class.</para>
+    ///     <para xml:lang="zh">初始化 <see cref="WebSocketMessageReceivedEventArgs" /> 类的新实例。</para>
+    /// </summary>
+    /// <param name="data">
+    ///     <para xml:lang="en">The received message data.</para>
+    ///     <para xml:lang="zh">接收到的消息数据。</para>
+    /// </param>
+    /// <param name="messageType">
+    ///     <para xml:lang="en">The type of the WebSocket message.</para>
+    ///     <para xml:lang="zh">WebSocket 消息类型。</para>
+    /// </param>
+    /// <param name="endOfMessage">
+    ///     <para xml:lang="en">Whether this is the end of the message.</para>
+    ///     <para xml:lang="zh">是否为消息结尾。</para>
+    /// </param>
+    public WebSocketMessageReceivedEventArgs(ReadOnlyMemory<byte> data, WebSocketMessageType messageType, bool endOfMessage)
+    {
+        Data = data;
+        MessageType = messageType;
+        EndOfMessage = endOfMessage;
+    }
+
+    /// <summary>
+    ///     <para xml:lang="en">
+    ///     Initializes a new instance with an associated <see cref="ArrayPool{T}" />-rented buffer
+    ///     that will be returned on <see cref="Dispose" />.
+    ///     </para>
+    ///     <para xml:lang="zh">
+    ///     使用关联的 <see cref="ArrayPool{T}" /> 租用缓冲区初始化新实例，该缓冲区将在 <see cref="Dispose" /> 时归还。
+    ///     </para>
+    /// </summary>
+    internal WebSocketMessageReceivedEventArgs(ReadOnlyMemory<byte> data, WebSocketMessageType messageType, bool endOfMessage, byte[]? rentedArray)
+        : this(data, messageType, endOfMessage)
+    {
+        _rentedArray = rentedArray;
+    }
 
     /// <summary>
     ///     <para xml:lang="en">Gets the received message data.</para>
     ///     <para xml:lang="zh">获取接收到的消息数据。</para>
     /// </summary>
-    public ReadOnlyMemory<byte> Data { get; } = data;
+    public ReadOnlyMemory<byte> Data { get; }
 
     /// <summary>
     ///     <para xml:lang="en">Gets the type of the WebSocket message.</para>
     ///     <para xml:lang="zh">获取 WebSocket 消息类型。</para>
     /// </summary>
-    public WebSocketMessageType MessageType { get; } = messageType;
+    public WebSocketMessageType MessageType { get; }
 
     /// <summary>
     ///     <para xml:lang="en">Gets a value indicating whether this is the end of the message.</para>
     ///     <para xml:lang="zh">获取一个值，指示这是否是消息的结尾。</para>
     /// </summary>
-    public bool EndOfMessage { get; } = endOfMessage;
+    public bool EndOfMessage { get; }
 
     /// <summary>
     ///     <para xml:lang="en">Returns the rented buffer to <see cref="System.Buffers.ArrayPool{T}" />. Called by <see cref="ManagedWebSocketClient" /> after all subscribers have returned.</para>

--- a/src/EasilyNET.Core/WebSocket/WebSocketEventArgs.cs
+++ b/src/EasilyNET.Core/WebSocket/WebSocketEventArgs.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Net.WebSockets;
 
 // ReSharper disable UnusedMember.Global
@@ -9,14 +10,6 @@ namespace EasilyNET.Core.WebSocket;
 ///     <para xml:lang="en">Event arguments for WebSocket state changes.</para>
 ///     <para xml:lang="zh">WebSocket 状态变更事件参数。</para>
 /// </summary>
-/// <param name="previousState">
-///     <para xml:lang="en">The previous state.</para>
-///     <para xml:lang="zh">先前的状态。</para>
-/// </param>
-/// <param name="currentState">
-///     <para xml:lang="en">The current state.</para>
-///     <para xml:lang="zh">当前状态。</para>
-/// </param>
 public sealed class WebSocketStateChangedEventArgs(WebSocketClientState previousState, WebSocketClientState currentState) : EventArgs
 {
     /// <summary>
@@ -33,23 +26,14 @@ public sealed class WebSocketStateChangedEventArgs(WebSocketClientState previous
 }
 
 /// <summary>
-///     <para xml:lang="en">Event arguments for received WebSocket messages.</para>
-///     <para xml:lang="zh">接收到的 WebSocket 消息事件参数。</para>
+///     <para>接收到的 WebSocket 消息事件参数（已重大改进）</para>
+///     <para>现在实现 <see cref="IDisposable" />，内部持有 ArrayPool 租用的缓冲区。</para>
+///     <para>强烈推荐在事件处理函数中使用 <c>using</c> 语句归还缓冲区，避免内存泄漏和 GC 压力。</para>
 /// </summary>
-/// <param name="data">
-///     <para xml:lang="en">The message data.</para>
-///     <para xml:lang="zh">消息数据。</para>
-/// </param>
-/// <param name="messageType">
-///     <para xml:lang="en">The type of the message.</para>
-///     <para xml:lang="zh">消息类型。</para>
-/// </param>
-/// <param name="endOfMessage">
-///     <para xml:lang="en">Whether this is the end of the message.</para>
-///     <para xml:lang="zh">是否为消息结尾。</para>
-/// </param>
-public sealed class WebSocketMessageReceivedEventArgs(ReadOnlyMemory<byte> data, WebSocketMessageType messageType, bool endOfMessage) : EventArgs
+public sealed class WebSocketMessageReceivedEventArgs(ReadOnlyMemory<byte> data, WebSocketMessageType messageType, bool endOfMessage, byte[]? rentedArray = null) : EventArgs, IDisposable
 {
+    private byte[]? _rentedArray = rentedArray;
+
     /// <summary>
     ///     <para xml:lang="en">Gets the received message data.</para>
     ///     <para xml:lang="zh">获取接收到的消息数据。</para>
@@ -67,6 +51,19 @@ public sealed class WebSocketMessageReceivedEventArgs(ReadOnlyMemory<byte> data,
     ///     <para xml:lang="zh">获取一个值，指示这是否是消息的结尾。</para>
     /// </summary>
     public bool EndOfMessage { get; } = endOfMessage;
+
+    /// <summary>
+    /// 归还缓冲区到 ArrayPool
+    /// </summary>
+    public void Dispose()
+    {
+        if (_rentedArray is null)
+        {
+            return;
+        }
+        ArrayPool<byte>.Shared.Return(_rentedArray);
+        _rentedArray = null;
+    }
 }
 
 /// <summary>

--- a/src/EasilyNET.Core/WebSocket/WebSocketEventArgs.cs
+++ b/src/EasilyNET.Core/WebSocket/WebSocketEventArgs.cs
@@ -26,9 +26,17 @@ public sealed class WebSocketStateChangedEventArgs(WebSocketClientState previous
 }
 
 /// <summary>
-///     <para>接收到的 WebSocket 消息事件参数（已重大改进）</para>
-///     <para>现在实现 <see cref="IDisposable" />，内部持有 ArrayPool 租用的缓冲区。</para>
-///     <para>强烈推荐在事件处理函数中使用 <c>using</c> 语句归还缓冲区，避免内存泄漏和 GC 压力。</para>
+///     <para xml:lang="en">
+///     Event arguments for a received WebSocket message. Implements <see cref="IDisposable" /> to return the internal
+///     <see cref="System.Buffers.ArrayPool{T}" /> buffer. The buffer is owned and disposed by
+///     <see cref="ManagedWebSocketClient" /> immediately after all event subscribers return — <see cref="Data" /> is only
+///     valid for the duration of the event callback and must not be stored or accessed after the handler returns.
+///     </para>
+///     <para xml:lang="zh">
+///     已接收的 WebSocket 消息事件参数。实现 <see cref="IDisposable" /> 以归还内部
+///     <see cref="System.Buffers.ArrayPool{T}" /> 缓冲区。缓冲区由 <see cref="ManagedWebSocketClient" />
+///     在所有事件订阅者返回后统一释放——<see cref="Data" /> 仅在事件回调期间有效，处理函数返回后不得存储或访问。
+///     </para>
 /// </summary>
 public sealed class WebSocketMessageReceivedEventArgs(ReadOnlyMemory<byte> data, WebSocketMessageType messageType, bool endOfMessage, byte[]? rentedArray = null) : EventArgs, IDisposable
 {
@@ -53,7 +61,8 @@ public sealed class WebSocketMessageReceivedEventArgs(ReadOnlyMemory<byte> data,
     public bool EndOfMessage { get; } = endOfMessage;
 
     /// <summary>
-    /// 归还缓冲区到 ArrayPool
+    ///     <para xml:lang="en">Returns the rented buffer to <see cref="System.Buffers.ArrayPool{T}" />. Called by <see cref="ManagedWebSocketClient" /> after all subscribers have returned.</para>
+    ///     <para xml:lang="zh">将租用的缓冲区归还给 <see cref="System.Buffers.ArrayPool{T}" />。由 <see cref="ManagedWebSocketClient" /> 在所有订阅者返回后调用。</para>
     /// </summary>
     public void Dispose()
     {

--- a/src/EasilyNET.Core/WebSocket/WebSocketEventArgs.cs
+++ b/src/EasilyNET.Core/WebSocket/WebSocketEventArgs.cs
@@ -38,32 +38,25 @@ public sealed class WebSocketStateChangedEventArgs(WebSocketClientState previous
 ///     在所有事件订阅者返回后统一释放——<see cref="Data" /> 仅在事件回调期间有效，处理函数返回后不得存储或访问。
 ///     </para>
 /// </summary>
-public sealed class WebSocketMessageReceivedEventArgs : EventArgs, IDisposable
+/// <remarks>
+///     <para xml:lang="en">Initializes a new instance of the <see cref="WebSocketMessageReceivedEventArgs" /> class.</para>
+///     <para xml:lang="zh">初始化 <see cref="WebSocketMessageReceivedEventArgs" /> 类的新实例。</para>
+/// </remarks>
+/// <param name="data">
+///     <para xml:lang="en">The received message data.</para>
+///     <para xml:lang="zh">接收到的消息数据。</para>
+/// </param>
+/// <param name="messageType">
+///     <para xml:lang="en">The type of the WebSocket message.</para>
+///     <para xml:lang="zh">WebSocket 消息类型。</para>
+/// </param>
+/// <param name="endOfMessage">
+///     <para xml:lang="en">Whether this is the end of the message.</para>
+///     <para xml:lang="zh">是否为消息结尾。</para>
+/// </param>
+public sealed class WebSocketMessageReceivedEventArgs(ReadOnlyMemory<byte> data, WebSocketMessageType messageType, bool endOfMessage) : EventArgs, IDisposable
 {
     private byte[]? _rentedArray;
-
-    /// <summary>
-    ///     <para xml:lang="en">Initializes a new instance of the <see cref="WebSocketMessageReceivedEventArgs" /> class.</para>
-    ///     <para xml:lang="zh">初始化 <see cref="WebSocketMessageReceivedEventArgs" /> 类的新实例。</para>
-    /// </summary>
-    /// <param name="data">
-    ///     <para xml:lang="en">The received message data.</para>
-    ///     <para xml:lang="zh">接收到的消息数据。</para>
-    /// </param>
-    /// <param name="messageType">
-    ///     <para xml:lang="en">The type of the WebSocket message.</para>
-    ///     <para xml:lang="zh">WebSocket 消息类型。</para>
-    /// </param>
-    /// <param name="endOfMessage">
-    ///     <para xml:lang="en">Whether this is the end of the message.</para>
-    ///     <para xml:lang="zh">是否为消息结尾。</para>
-    /// </param>
-    public WebSocketMessageReceivedEventArgs(ReadOnlyMemory<byte> data, WebSocketMessageType messageType, bool endOfMessage)
-    {
-        Data = data;
-        MessageType = messageType;
-        EndOfMessage = endOfMessage;
-    }
 
     /// <summary>
     ///     <para xml:lang="en">
@@ -84,22 +77,25 @@ public sealed class WebSocketMessageReceivedEventArgs : EventArgs, IDisposable
     ///     <para xml:lang="en">Gets the received message data.</para>
     ///     <para xml:lang="zh">获取接收到的消息数据。</para>
     /// </summary>
-    public ReadOnlyMemory<byte> Data { get; }
+    public ReadOnlyMemory<byte> Data { get; } = data;
 
     /// <summary>
     ///     <para xml:lang="en">Gets the type of the WebSocket message.</para>
     ///     <para xml:lang="zh">获取 WebSocket 消息类型。</para>
     /// </summary>
-    public WebSocketMessageType MessageType { get; }
+    public WebSocketMessageType MessageType { get; } = messageType;
 
     /// <summary>
     ///     <para xml:lang="en">Gets a value indicating whether this is the end of the message.</para>
     ///     <para xml:lang="zh">获取一个值，指示这是否是消息的结尾。</para>
     /// </summary>
-    public bool EndOfMessage { get; }
+    public bool EndOfMessage { get; } = endOfMessage;
 
     /// <summary>
-    ///     <para xml:lang="en">Returns the rented buffer to <see cref="System.Buffers.ArrayPool{T}" />. Called by <see cref="ManagedWebSocketClient" /> after all subscribers have returned.</para>
+    ///     <para xml:lang="en">
+    ///     Returns the rented buffer to <see cref="System.Buffers.ArrayPool{T}" />. Called by <see cref="ManagedWebSocketClient" />
+    ///     after all subscribers have returned.
+    ///     </para>
     ///     <para xml:lang="zh">将租用的缓冲区归还给 <see cref="System.Buffers.ArrayPool{T}" />。由 <see cref="ManagedWebSocketClient" /> 在所有订阅者返回后调用。</para>
     /// </summary>
     public void Dispose()

--- a/test/EasilyNET.Test.Unit/WebSocket/ManagedWebSocketClientMaxMessageSizeTest.cs
+++ b/test/EasilyNET.Test.Unit/WebSocket/ManagedWebSocketClientMaxMessageSizeTest.cs
@@ -8,6 +8,8 @@ namespace EasilyNET.Test.Unit.WebSocket;
 [TestClass]
 public class ManagedWebSocketClientMaxMessageSizeTest
 {
+    public TestContext TestContext { get; set; }
+
     /// <summary>
     /// 找一个本地可用的 TCP 端口（TOCTOU 竞争在本地测试中概率极低，可接受）。
     /// </summary>
@@ -72,7 +74,7 @@ public class ManagedWebSocketClientMaxMessageSizeTest
         {
             // 5 字节单帧，客户端限制为 4
             await ws.SendAsync(new byte[5], WebSocketMessageType.Binary, true, CancellationToken.None).ConfigureAwait(false);
-            await Task.Delay(500).ConfigureAwait(false);
+            await Task.Delay(500, TestContext.CancellationToken).ConfigureAwait(false);
         });
         var errorRaised = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
         await using var client = new ManagedWebSocketClient(new()
@@ -83,11 +85,11 @@ public class ManagedWebSocketClientMaxMessageSizeTest
             ReceiveBufferSize = 64
         });
         client.Error += (_, e) => errorRaised.TrySetResult(e.Exception);
-        await client.ConnectAsync();
-        var ex = await errorRaised.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await client.ConnectAsync(TestContext.CancellationToken);
+        var ex = await errorRaised.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
         AssertMaxMessageSizeExceeded(ex);
         httpListener.Stop();
-        await serverTask.WaitAsync(TimeSpan.FromSeconds(3));
+        await serverTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.CancellationToken);
     }
 
     /// <summary>
@@ -101,7 +103,7 @@ public class ManagedWebSocketClientMaxMessageSizeTest
         {
             // 首帧 5 字节（endOfMessage=false）超出限制 4
             await ws.SendAsync(new byte[5], WebSocketMessageType.Binary, false, CancellationToken.None).ConfigureAwait(false);
-            await Task.Delay(500).ConfigureAwait(false);
+            await Task.Delay(500, TestContext.CancellationToken).ConfigureAwait(false);
         });
         var errorRaised = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
         await using var client = new ManagedWebSocketClient(new()
@@ -112,11 +114,11 @@ public class ManagedWebSocketClientMaxMessageSizeTest
             ReceiveBufferSize = 64
         });
         client.Error += (_, e) => errorRaised.TrySetResult(e.Exception);
-        await client.ConnectAsync();
-        var ex = await errorRaised.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await client.ConnectAsync(TestContext.CancellationToken);
+        var ex = await errorRaised.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
         AssertMaxMessageSizeExceeded(ex);
         httpListener.Stop();
-        await serverTask.WaitAsync(TimeSpan.FromSeconds(3));
+        await serverTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.CancellationToken);
     }
 
     /// <summary>
@@ -131,7 +133,7 @@ public class ManagedWebSocketClientMaxMessageSizeTest
             // 两帧各 3 字节：单帧均不超限（3 ≤ 4），但累积 6 > 4
             await ws.SendAsync(new byte[3], WebSocketMessageType.Binary, false, CancellationToken.None).ConfigureAwait(false);
             await ws.SendAsync(new byte[3], WebSocketMessageType.Binary, true, CancellationToken.None).ConfigureAwait(false);
-            await Task.Delay(500).ConfigureAwait(false);
+            await Task.Delay(500, TestContext.CancellationToken).ConfigureAwait(false);
         });
         var errorRaised = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
         await using var client = new ManagedWebSocketClient(new()
@@ -142,11 +144,11 @@ public class ManagedWebSocketClientMaxMessageSizeTest
             ReceiveBufferSize = 64
         });
         client.Error += (_, e) => errorRaised.TrySetResult(e.Exception);
-        await client.ConnectAsync();
-        var ex = await errorRaised.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await client.ConnectAsync(TestContext.CancellationToken);
+        var ex = await errorRaised.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
         AssertMaxMessageSizeExceeded(ex);
         httpListener.Stop();
-        await serverTask.WaitAsync(TimeSpan.FromSeconds(3));
+        await serverTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.CancellationToken);
     }
 
     /// <summary>
@@ -160,7 +162,7 @@ public class ManagedWebSocketClientMaxMessageSizeTest
         var serverTask = RunServerAsync(httpListener, async ws =>
         {
             await ws.SendAsync(payload, WebSocketMessageType.Binary, true, CancellationToken.None).ConfigureAwait(false);
-            await Task.Delay(500).ConfigureAwait(false);
+            await Task.Delay(500, TestContext.CancellationToken).ConfigureAwait(false);
         });
         var messageReceived = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         var errorRaised = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -175,12 +177,12 @@ public class ManagedWebSocketClientMaxMessageSizeTest
         });
         client.MessageReceived += (_, e) => messageReceived.TrySetResult(e.Data.ToArray());
         client.Error += (_, e) => errorRaised.TrySetResult(e.Exception);
-        await client.ConnectAsync();
-        var completedTask = await Task.WhenAny(messageReceived.Task, errorRaised.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        await client.ConnectAsync(TestContext.CancellationToken);
+        var completedTask = await Task.WhenAny(messageReceived.Task, errorRaised.Task, Task.Delay(TimeSpan.FromSeconds(5), TestContext.CancellationToken));
         Assert.AreSame(messageReceived.Task, completedTask, "Expected MessageReceived event, but got Error or timeout.");
         CollectionAssert.AreEqual(payload, await messageReceived.Task);
         httpListener.Stop();
-        await serverTask.WaitAsync(TimeSpan.FromSeconds(3));
+        await serverTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.CancellationToken);
     }
 
     /// <summary>
@@ -196,7 +198,7 @@ public class ManagedWebSocketClientMaxMessageSizeTest
         var serverTask = RunServerAsync(httpListener, async ws =>
         {
             await ws.SendAsync(payload, WebSocketMessageType.Binary, true, CancellationToken.None).ConfigureAwait(false);
-            await Task.Delay(500).ConfigureAwait(false);
+            await Task.Delay(500, TestContext.CancellationToken).ConfigureAwait(false);
         });
         var messageReceived = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         var errorRaised = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -210,12 +212,12 @@ public class ManagedWebSocketClientMaxMessageSizeTest
         });
         client.MessageReceived += (_, e) => messageReceived.TrySetResult(e.Data.ToArray());
         client.Error += (_, e) => errorRaised.TrySetResult(e.Exception);
-        await client.ConnectAsync();
-        var completedTask = await Task.WhenAny(messageReceived.Task, errorRaised.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        await client.ConnectAsync(TestContext.CancellationToken);
+        var completedTask = await Task.WhenAny(messageReceived.Task, errorRaised.Task, Task.Delay(TimeSpan.FromSeconds(5), TestContext.CancellationToken));
         Assert.AreSame(messageReceived.Task, completedTask, "Expected MessageReceived event, but got Error or timeout.");
         CollectionAssert.AreEqual(payload, await messageReceived.Task);
         httpListener.Stop();
-        await serverTask.WaitAsync(TimeSpan.FromSeconds(3));
+        await serverTask.WaitAsync(TimeSpan.FromSeconds(3), TestContext.CancellationToken);
     }
 
     private static void AssertMaxMessageSizeExceeded(Exception ex)

--- a/test/EasilyNET.Test.Unit/WebSocket/ManagedWebSocketClientMaxMessageSizeTest.cs
+++ b/test/EasilyNET.Test.Unit/WebSocket/ManagedWebSocketClientMaxMessageSizeTest.cs
@@ -85,8 +85,7 @@ public class ManagedWebSocketClientMaxMessageSizeTest
         client.Error += (_, e) => errorRaised.TrySetResult(e.Exception);
         await client.ConnectAsync();
         var ex = await errorRaised.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.IsInstanceOfType<InvalidOperationException>(ex);
-        Assert.Contains("exceeded maximum allowed size", ex.Message);
+        AssertMaxMessageSizeExceeded(ex);
         httpListener.Stop();
         await serverTask.WaitAsync(TimeSpan.FromSeconds(3));
     }
@@ -115,8 +114,7 @@ public class ManagedWebSocketClientMaxMessageSizeTest
         client.Error += (_, e) => errorRaised.TrySetResult(e.Exception);
         await client.ConnectAsync();
         var ex = await errorRaised.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.IsInstanceOfType<InvalidOperationException>(ex);
-        Assert.Contains("exceeded maximum allowed size", ex.Message);
+        AssertMaxMessageSizeExceeded(ex);
         httpListener.Stop();
         await serverTask.WaitAsync(TimeSpan.FromSeconds(3));
     }
@@ -146,8 +144,7 @@ public class ManagedWebSocketClientMaxMessageSizeTest
         client.Error += (_, e) => errorRaised.TrySetResult(e.Exception);
         await client.ConnectAsync();
         var ex = await errorRaised.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.IsInstanceOfType<InvalidOperationException>(ex);
-        Assert.Contains("exceeded maximum allowed size", ex.Message);
+        AssertMaxMessageSizeExceeded(ex);
         httpListener.Stop();
         await serverTask.WaitAsync(TimeSpan.FromSeconds(3));
     }
@@ -219,5 +216,12 @@ public class ManagedWebSocketClientMaxMessageSizeTest
         CollectionAssert.AreEqual(payload, await messageReceived.Task);
         httpListener.Stop();
         await serverTask.WaitAsync(TimeSpan.FromSeconds(3));
+    }
+
+    private static void AssertMaxMessageSizeExceeded(Exception ex)
+    {
+        Assert.IsInstanceOfType<InvalidOperationException>(ex);
+        Assert.Contains("exceeded", ex.Message);
+        Assert.Contains("MaxMessageSize", ex.Message);
     }
 }


### PR DESCRIPTION
- [x] Understand all review comments and plan changes
- [x] Fix `WebSocketEventArgs.cs`: update comments - client owns buffer lifetime, not subscribers
- [x] Fix `WebSocketClientOptions.cs`: add `ApplyTo(ClientWebSocket)` method to apply `KeepAliveInterval` and `RequestedSubProtocols`
- [x] Fix `ManagedWebSocketClient.cs` - `StartConnectionAsync`: call `Options.ApplyTo(session.Socket)` to apply new options
- [x] Fix `ManagedWebSocketClient.cs` - PersistentSendLoop: use linked CTS (`_disposeCts.Token` + `currentSession.Token`)
- [x] Fix `ManagedWebSocketClient.cs` - receive path: use `using var args` so client disposes buffer after invoking all subscribers
- [x] Fix `ManagedWebSocketClient.cs` - `IsHeartbeatResponse`: change `Span<byte>` to `ReadOnlySpan<byte>`
- [x] Fix `ManagedWebSocketClient.cs` - `FailPendingSends`: use `TrySetCanceled` for `OperationCanceledException`
- [x] Fix bilingual comment in ReceiveLoop
- [x] Build & validate changes (net10.0 compiles cleanly; 3 pre-existing test failures unrelated to these changes)
- [x] Run parallel_validation (0 CodeQL alerts, minor style notes)