### PR TITLE
ci: 🔧 NuGet 发布切换为 Trusted Publishing(OIDC)

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -2,6 +2,8 @@ name: Release
 permissions:
   contents: read
   pull-requests: write
+  # NuGet Trusted Publishing(OIDC) 需要请求 GitHub 身份令牌
+  id-token: write
 
 on:
   push:
@@ -24,8 +26,9 @@ jobs:
     defaults:
       run:
         shell: bash
+    # 该名称必须与 nuget.org 上 Trusted Publishing 策略中的 Environment 一致
     environment:
-      name: NUGET_ENV
+      name: Release
     steps:
       # Windows Only
       #- name: Set Timezone
@@ -79,9 +82,17 @@ jobs:
         run: ./Pack.ps1
         shell: pwsh
 
+      # 通过 OIDC 换取 nuget.org 的短期 API Key(有效期 1 小时),不再使用长期密钥
+      # user 为 nuget.org 的用户名(profile name),非邮箱
+      - name: NuGet Login (Trusted Publishing)
+        uses: NuGet/login@v1
+        id: nuget_login
+        with:
+          user: joes_du
+
       - name: Push to NuGet
         env:
-          NUGET_URL: ${{ vars.NUGET_URL }}
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_URL: https://api.nuget.org/v3/index.json
+          NUGET_API_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
         run: ./Push.ps1
         shell: pwsh


### PR DESCRIPTION
## 做了什么

将 NuGet 发布从长期 API Key 切换为 **Trusted Publishing(OIDC)**。

- 新增 `id-token: write` 权限,允许工作流请求 GitHub OIDC 令牌
- 发布 Job 的 `environment` 由 `NUGET_ENV` 改为 `Release`,与 nuget.org 上已配置的 Trusted Publishing 策略(Repository Owner: joesdu / Repository: EasilyNET / Workflow: releaser.yml / Environment: Release)保持一致
- 新增 `NuGet/login@v1` 步骤,用 OIDC 令牌换取有效期 1 小时的短期 API Key,并注入 `Push.ps1`
- `NUGET_URL` 直接写入工作流,不再依赖 `vars.NUGET_URL`

## 为什么

nuget.org 已强烈建议自动化发布弃用长期 API Key。上一次 `6.26.813.101` 的发布流水线在 Push 阶段因 `403 The specified API key is invalid, has expired...` 失败。

## 影响范围

仅 `.github/workflows/releaser.yml`,`Pack.ps1` / `Push.ps1` 无需改动。合并后重新打标签即可触发发布。

🤖 Generated with [Claude Code](https://claude.com/claude-code)