### PR TITLE
docs: 📝 更新 AGENTS.md 中的发布环境说明

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ docker compose -f docker-compose.mongo.rs.yml up -d       # MongoDB replica set
 
 - Requires latest .NET SDK (preview features, no global.json pinning)
 - CI runs on ubuntu-latest with pwsh shell, installs both .NET 10 and 11 preview SDKs
-- Release triggered by git tag `*.*.*` → Pack.ps1 → Push.ps1 to NuGet (NUGET_ENV environment)
+- Release triggered by git tag `*.*.*` → Pack.ps1 → Push.ps1 to NuGet (`Release` environment, Trusted Publishing via OIDC — no long-lived API key)
 - `sample/WebApi.Test.Unit` demonstrates module orchestration via `DependsOn` attribute
 - Each `src/` project has its own `README.md` with usage details
 - Serilog + OpenTelemetry pipeline in sample for observability


### PR DESCRIPTION
## 做了什么

同步 `AGENTS.md` 中的发布流程说明：`NUGET_ENV` 环境 → `Release` 环境 + Trusted Publishing(OIDC)。

## 为什么

#1270 已将 NuGet 发布切换为 Trusted Publishing，旧的 `NUGET_ENV` 环境（及其中的 `NUGET_API_KEY` / `NUGET_URL`）已从仓库设置中删除，文档中的描述随之失效。

## 影响范围

仅文档一行，无代码/构建影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)